### PR TITLE
Handle None as return value for call_pkg_config

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -861,7 +861,7 @@ Rosstackage::cpp_exports(const std::string& name, const std::string& type,
         if(pValue == Py_None)
         {
           Py_DECREF(pValue);
-          std::string errmsg = "python function 'rosdep2.rospack.call_pkg_config' returned no value";
+          std::string errmsg = "pkg-config failed for package '"+ (*it)->name_ +"' in python function 'rosdep2.rospack.call_pkg_config'";
           throw Exception(errmsg);
         }
 

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -858,6 +858,12 @@ Rosstackage::cpp_exports(const std::string& name, const std::string& type,
           std::string errmsg = "could not call python function 'rosdep2.rospack.call_pkg_config'";
           throw Exception(errmsg);
         }
+        if(pValue == Py_None)
+        {
+          Py_DECREF(pValue);
+          std::string errmsg = "python function 'rosdep2.rospack.call_pkg_config' returned no value";
+          throw Exception(errmsg);
+        }
 
         flags.push_back(std::pair<std::string, bool>(PyString_AsString(pValue), true));
         Py_DECREF(pValue);


### PR DESCRIPTION
Part of a proposed fix for ros/rosdep#34

A failed call to pkg-config should give a more
clear error message instead of a stack trace.
