### PR TITLE
Minimal logic for windows build with groovy catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,13 @@ find_package(catkin REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem program_options system)
 set(Python_ADDITIONAL_VERSIONS 2.7)
 find_package(PythonLibs REQUIRED)
+find_package(tinyxml QUIET)
+if(NOT tinyxml_FOUND)
+  # Just assume it's located in the system directories
+  # though you could try and detect stuff via the pkgconfig file
+  # it provides
+  set(tinyxml_LIBRARIES tinyxml)
+endif() 
 
 catkin_package(
   INCLUDE_DIRS include
@@ -20,7 +27,7 @@ if(API_BACKCOMPAT_V1)
   set(backcompat_source src/rospack_backcompat.cpp)
 endif()
 
-include_directories(include ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
+include_directories(include ${tinyxml_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 
 add_library(rospack
   src/rospack.cpp
@@ -28,7 +35,7 @@ add_library(rospack
   src/rospack_cmdline.cpp
   src/utils.cpp
 )
-target_link_libraries(rospack tinyxml ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
+target_link_libraries(rospack ${tinyxml_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 
 add_executable(rospackexe src/rospack_main.cpp)
 # Set the name, and make it a "global" executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ catkin_package(
   DEPENDS Boost
 )
 
-add_definitions(-Wall)
+#add_definitions(-Wall)
 
 set(API_BACKCOMPAT_V1 "YES" CACHE BOOL "Whether to enable backwards compatibility with old C++ API")
 if(API_BACKCOMPAT_V1)

--- a/include/rospack/macros.h
+++ b/include/rospack/macros.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2008, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSPACK_MACROS_H_
+#define ROSPACK_MACROS_H_
+
+/*
+ * Windows macros for dll exports
+ *
+ * This replicates what ros has in roscpp_core/cpp_common/macros.h
+ * so rospack can be standalone.
+ *
+ * See also http://gcc.gnu.org/wiki/Visibility
+ */
+
+#if defined(_MSC_VER)
+    #define ROS_HELPER_IMPORT __declspec(dllimport)
+    #define ROS_HELPER_EXPORT __declspec(dllexport)
+    #define ROS_HELPER_LOCAL
+#elif __GNUC__ >= 4
+    #define ROS_HELPER_IMPORT __attribute__ ((visibility("default")))
+    #define ROS_HELPER_EXPORT __attribute__ ((visibility("default")))
+    #define ROS_HELPER_LOCAL  __attribute__ ((visibility("hidden")))
+#else
+    #define ROS_HELPER_IMPORT
+    #define ROS_HELPER_EXPORT
+    #define ROS_HELPER_LOCAL
+#endif
+
+// Ignore warnings about import/exports when deriving from std classes.
+#ifdef _MSC_VER
+  #pragma warning(disable:4251)
+  #pragma warning(disable:4275)
+  #pragma warning(disable:4514) // unreferenced inline function has been removed
+  #pragma warning(disable:4668) // warnigns about used, but not defined macros, replacing with 0
+  #pragma warning(disable:4710) // function not inlined
+  #pragma warning(disable:4738) // storing floats, memory splitting, possible loss in performance
+  #pragma warning(disable:4820) // structs and padding
+#endif
+
+#ifdef ROS_BUILD_STATIC_LIBS // ros is being built around shared libraries
+  #define ROSPACK_DECL
+#else // ros is being built around shared libraries
+  #ifdef rospack_EXPORTS // we are building a shared lib/dll
+    #define ROSPACK_DECL ROS_HELPER_EXPORT
+  #else // we are using shared lib/dll
+    #define ROSPACK_DECL ROS_HELPER_IMPORT
+  #endif
+#endif
+
+#endif /* ROSPACK_MACROS_H_ */

--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -111,6 +111,7 @@ and Rosstack.
 #include <vector>
 #include <set>
 #include <list>
+#include "macros.h"
 
 //#ifdef ROSPACK_API_BACKCOMPAT_V1
 #if 1 // def ROSPACK_API_BACKCOMPAT_V1
@@ -136,7 +137,7 @@ class DirectoryCrawlRecord;
  * use the functionality provided here through one of the derived classes,
  * Rosstack or Rospack.
  */
-class Rosstackage
+class ROSPACK_DECL Rosstackage
 {
   private:
     std::string manifest_name_;
@@ -525,7 +526,7 @@ re-run the profile with --zombie-only
  * @brief Package crawler.  Create one of these to operate on a package
  * tree.  Call public methods inherited from Rosstackage.
  */
-class Rospack : public Rosstackage
+class ROSPACK_DECL Rospack : public Rosstackage
 {
   public:
     /**
@@ -543,7 +544,7 @@ class Rospack : public Rosstackage
  * @brief Stack crawler.  Create one of these to operate on a stack
  * tree.  Call public methods inherited from Rosstackage.
  */
-class Rosstack : public Rosstackage
+class ROSPACK_DECL Rosstack : public Rosstackage
 {
   public:
     /**

--- a/include/rospack/rospack_backcompat.h
+++ b/include/rospack/rospack_backcompat.h
@@ -30,6 +30,7 @@
 #define ROSPACK_ROSPACK_BACKCOMPAT_H
 
 #include <string>
+#include "macros.h"
 
 namespace rospack
 {
@@ -38,7 +39,7 @@ namespace rospack
  * @brief Backward compatibility API for librospack (DEPRECATED).
  * @deprecated Used by roslib.  Don't use in new code.
  */
-class ROSPack
+class ROSPACK_DECL ROSPack
 {
   private:
     std::string output_;

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -37,8 +37,20 @@
 #if defined(WIN32)
   #include <windows.h>
   #include <direct.h>
-  #include <libgen.h> // for dirname
   #include <fcntl.h>  // for O_RDWR, O_EXCL, O_CREAT
+  // simple workaround - could have issues though. See
+  //   http://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
+  // for potentially better solutions. Similar probably applies for some of the others
+  #define snprintf _snprintf
+  #define pclose _pclose
+  #define popen _popen
+  #define PATH_MAX MAX_PATH
+  #if defined(__MINGW32__)
+    #include <libgen.h> // for dirname
+  #endif
+  #if defined(_MSC_VER)
+    #include <io.h> // _mktemp_s
+  #endif
 #else //!defined(WIN32)
   #include <sys/types.h>
   #include <libgen.h>

--- a/src/rospack_cmdline.cpp
+++ b/src/rospack_cmdline.cpp
@@ -27,6 +27,7 @@
 
 #include "rospack/rospack.h"
 #include "utils.h"
+#include "rospack_cmdline.h"
 
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/rospack_cmdline.h
+++ b/src/rospack_cmdline.h
@@ -28,12 +28,13 @@
 #ifndef ROSPACK_ROSPACK_CMDLINE_H
 #define ROSPACK_ROSPACK_CMDLINE_H
 
+#include "rospack/macros.h"
 #include "rospack/rospack.h"
 
 namespace rospack
 {
 
-bool rospack_run(int argc, char** argv, 
+ROSPACK_DECL bool rospack_run(int argc, char** argv,
                  rospack::Rosstackage& rp, 
                  std::string& output);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -29,7 +29,9 @@
 #include <vector>
 #include <boost/algorithm/string.hpp>
 #include <boost/tr1/unordered_set.hpp>
-        
+
+#include "utils.h"
+
 namespace rospack
 {
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,6 +29,7 @@
 #define ROSPACK_UTILS_H
 
 #include <string>
+#include "rospack/macros.h"
 
 namespace rospack
 {
@@ -37,12 +38,11 @@ namespace rospack
 static const char* ROSPACK_NAME = "rospack";
 static const char* ROSSTACK_NAME = "rosstack";
 
-void deduplicate_tokens(const std::string& instring, 
+ROSPACK_DECL void deduplicate_tokens(const std::string& instring,
                         bool last,
                         std::string& outstring);
 
-void
-parse_compiler_flags(const std::string& instring, 
+ROSPACK_DECL void parse_compiler_flags(const std::string& instring,
                      const std::string& token,
                      bool select,
                      bool last,


### PR DESCRIPTION
Adds the following for a windows build:
- Library exports for the dll's
- Correct header usage for msvc
- Logic for tinyxml find_package module (exists on windows), fallback to system search otherwise.

Ros and rospack stacks finally building with groovy catkin!
