### PR TITLE
add depends-dot, replacement of rxdep

### DIFF
--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -109,6 +109,7 @@ and Rosstack.
 #include <boost/tr1/unordered_map.hpp>
 #include <string>
 #include <vector>
+#include <map>
 #include <set>
 #include <list>
 
@@ -176,6 +177,8 @@ class Rosstackage
                         std::vector<Stackage*>& deps,
                         bool get_indented_deps,
                         std::vector<std::string>& indented_deps,
+                        bool get_dot_deps,
+                        std::map<std::string, std::vector<std::string> >& dot_deps,
                         bool no_recursion_on_wet=false);
     std::string getCachePath();
     bool readCache();
@@ -365,6 +368,32 @@ rostime
      */
     bool depsIndent(const std::string& name, bool direct,
                     std::vector<std::string>& deps);
+    /**
+     * @brief Generate dot format of a stackage's dependencies,
+     * including duplicates.  Intended for visual debugging of dependency
+     * structures.
+     * @param name The stackage to work on.
+     * @param direct If true, then compute only direct dependencies.  If
+     *               false, then compute full (including indirect)
+     *               dependencies.
+     * @param deps List of the stackage's dependencies, with leading spaces
+     * to indicate depth, is written here.  Print this list to console,
+     * with newlines separating each element.  Example output:
+@verbatim
+digraph "roscpp" \{
+   "roscpp_traits" -> "cpp_common"
+   "rostime" -> "cpp_common"
+\}
+@endverbatim
+     * To visualize, use following commnad:
+@verbatim
+rospack depends-dot roscpp | dot | xdot - 
+@endverbatim
+     * @return True if the dot dependencies were computed, false
+     * otherwise.
+     */
+    bool depsDot(const std::string& name, bool direct,
+                 std::vector<std::string>& deps);
     /**
      * @brief Compute all dependency chains from one stackage to another.
      * Intended for visual debugging of dependency structures.

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -32,6 +32,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 #include <map>
+#include <algorithm>
 #include <stdexcept>
 
 #if defined(WIN32)
@@ -581,11 +582,48 @@ Rosstackage::depsIndent(const std::string& name, bool direct,
     std::vector<Stackage*> deps_vec;
     std::tr1::unordered_set<Stackage*> deps_hash;
     std::vector<std::string> indented_deps;
-    gatherDepsFull(stackage, direct, POSTORDER, 0, deps_hash, deps_vec, true, indented_deps);
+    std::map<std::string, std::vector<std::string> > dot_deps;
+    gatherDepsFull(stackage, direct, POSTORDER, 0, deps_hash, deps_vec, true, indented_deps, false, dot_deps);
     for(std::vector<std::string>::const_iterator it = indented_deps.begin();
         it != indented_deps.end();
         ++it)
       deps.push_back(*it);
+  }
+  catch(Exception& e)
+  {
+    logError(e.what());
+    return false;
+  }
+  return true;
+}
+
+bool
+Rosstackage::depsDot(const std::string& name, bool direct,
+                     std::vector<std::string>& deps)
+{
+  Stackage* stackage = findWithRecrawl(name);
+  if(!stackage)
+    return false;
+  try
+  {
+    computeDeps(stackage);
+    std::vector<Stackage*> deps_vec;
+    std::tr1::unordered_set<Stackage*> deps_hash;
+    std::vector<std::string> indented_deps;
+    std::map<std::string, std::vector<std::string> > dot_deps;
+    gatherDepsFull(stackage, direct, POSTORDER, 0, deps_hash, deps_vec, false, indented_deps, true, dot_deps);
+    deps.push_back("digraph \"" + name + "\" {");
+    deps.push_back("    node [shape=box]");
+    for(std::map<std::string, std::vector<std::string> >::const_iterator it = dot_deps.begin();
+        it != dot_deps.end();
+        ++it) {
+        for(std::vector<std::string>::const_iterator it2 = it->second.begin();
+            it2 != it->second.end();
+            it2++) {
+            deps.push_back("  \"" + it->first + "\" -> \"" + *it2 + "\";");
+            }
+    }
+    deps.push_back("}");
   }
   catch(Exception& e)
   {
@@ -1732,8 +1770,10 @@ Rosstackage::gatherDeps(Stackage* stackage, bool direct,
 {
   std::tr1::unordered_set<Stackage*> deps_hash;
   std::vector<std::string> indented_deps;
+  std::map<std::string, std::vector<std::string> > dot_deps;
   gatherDepsFull(stackage, direct, order, 0, 
-                 deps_hash, deps, false, indented_deps, no_recursion_on_wet);
+                 deps_hash, deps, false, indented_deps, 
+                 false, dot_deps, no_recursion_on_wet);
 }
 
 // Pre-condition: computeDeps(stackage) succeeded
@@ -1744,6 +1784,8 @@ Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
                             std::vector<Stackage*>& deps,
                             bool get_indented_deps,
                             std::vector<std::string>& indented_deps,
+                            bool get_dot_deps,
+                            std::map<std::string, std::vector<std::string> >& dot_deps,
                             bool no_recursion_on_wet)
 {
   if(stackage->is_wet_package_ && no_recursion_on_wet)
@@ -1776,6 +1818,16 @@ Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
         indented_deps.push_back(indented_dep);
     }
 
+    if(get_dot_deps)
+    {
+      std::string indented_dep;
+      std::vector<std::string>& deps = dot_deps[stackage->name_];
+      // check if it->names is already stored
+      if  ( std::find( deps.begin(), deps.end(), (*it)->name_ ) == deps.end() ) {
+          deps.push_back((*it)->name_);
+      }
+    }
+
     bool first = (deps_hash.find(*it) == deps_hash.end());
     if(first)
     {
@@ -1791,7 +1843,7 @@ Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
       // nth time, so that we'll throw an error on recursive dependencies
       // (detected via max stack depth being exceeded).
       gatherDepsFull(*it, direct, order, depth+1, deps_hash, deps,
-                     get_indented_deps, indented_deps);
+                     get_indented_deps, indented_deps, get_dot_deps, dot_deps);
     }
     if(first)
     {
@@ -2150,6 +2202,7 @@ Rospack::usage()
           "    cflags-only-I     [--deps-only] [package]\n"
           "    cflags-only-other [--deps-only] [package]\n"
           "    depends           [package] (alias: deps)\n"
+          "    depends-dot       [package] (alias: deps-dot)\n"
           "    depends-indent    [package] (alias: deps-indent)\n"
           "    depends-manifests [package] (alias: deps-manifests)\n"
           "    depends-msgsrv    [package] (alias: deps-msgsrv)\n"

--- a/src/rospack_cmdline.cpp
+++ b/src/rospack_cmdline.cpp
@@ -147,6 +147,8 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
         output.append("[package]\n\nPrint space-separated, ordered list of manifest.xml files for all dependencies of the package. Used internally by rosbuild.");
       else if(command == "depends-indent" || command == "deps-indent")
         output.append("[package]\n\nPrint newline-separated, indented list of the entire dependency chain for the package.");
+      else if(command == "depends-dot" || command == "deps-dot")
+        output.append("[package]\n\nPrint dot format of the entire dependency chain for the package.");
       else if(command == "depends-why" || command == "deps-why")
         output.append("--target=TARGET [package]\n\nPrint newline-separated presentation of all dependency chains from the package to TARGET. ");
       else if(command == "depends-msgsrv" || command == "deps-msgsrv")
@@ -434,6 +436,29 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
     }
     std::vector<std::string> deps;
     if(!rp.depsIndent(package, false, deps))
+      return false;
+    for(std::vector<std::string>::const_iterator it = deps.begin();
+        it != deps.end();
+        ++it)
+      output.append(*it + "\n");
+    return true;
+  }
+  // COMMAND: depends-dot [package] (alias: deps-dot)
+  else if(command == "depends-dot" || command == "deps-dot")
+  {
+    if(!package.size())
+    {
+      rp.logError( "no package/stack given");
+      return false;
+    }
+    if(target.size() || top.size() || length_str.size() || 
+       zombie_only || deps_only || lang.size() || attrib.size())
+    {
+      rp.logError( "invalid option(s) given");
+      return false;
+    }
+    std::vector<std::string> deps;
+    if(!rp.depsDot(package, false, deps))
       return false;
     for(std::vector<std::string>::const_iterator it = deps.begin();
         it != deps.end();

--- a/src/rostree_main.cpp
+++ b/src/rostree_main.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2008, Willow Garage, Inc.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rospack_cmdline.h"
+//#include "../src/rospack.cpp"
+#include "utils.h"
+
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+#include <algorithm>
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+
+namespace po = boost::program_options;
+
+int
+main(int argc, char** argv)
+{
+  rospack::Rospack rp;
+  std::string name = argv[1];
+
+  std::vector<std::string> search_path;
+  if(!rp.getSearchPathFromEnv(search_path))
+    return 1;
+
+  // We crawl here because profile (above) does its own special crawl.
+  rp.crawl(search_path, true);
+
+  rospack::Stackage* stackage = rp.findWithRecrawl(name); // private
+  if(!stackage)
+    return 1;
+  try
+  {
+    rp.computeDeps(stackage); // private
+    std::vector<rospack::Stackage*> deps_vec;
+    rp.gatherDeps(stackage, false, rospack::POSTORDER, deps_vec); // praivate
+    std::cout <<"digraph \"" << name << "\" {" << std::endl;
+    for(std::vector<rospack::Stackage*>::const_iterator it = deps_vec.begin();
+        it != deps_vec.end();
+        ++it) {
+        for(std::vector<rospack::Stackage*>::const_iterator it2 = (*it)->deps_.begin();
+            it2 != (*it)->deps_.end();
+            ++it2) {
+            std::cout << "\"" << (*it)->name_ << "\" -> \"" << (*it2)->name_ << "\"" << std::endl;
+        }
+    }
+    std::cout <<"}" << std::endl;
+  } catch (...) {
+  }
+
+  //printf("%s", output.c_str());
+  return 0;
+}
+


### PR DESCRIPTION
Add depends-dot command in order to provide equivalent function of rxdeps (http://www.ros.org/wiki/rxdeps).  use following command to see depends tree:

rospack depends-dot roscpp | dot | xdot -                                       
