### PR TITLE
modified command 'list-duplicates' to output the paths where the packages were found (fix #3)

### DIFF
--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -147,7 +147,7 @@ class ROSPACK_DECL Rosstackage
     std::string tag_;
     bool quiet_;
     std::vector<std::string> search_paths_;
-    std::tr1::unordered_set<std::string> dups_;
+    std::tr1::unordered_map<std::string, std::vector<std::string> > dups_;
     std::tr1::unordered_map<std::string, Stackage*> stackages_;
     Stackage* findWithRecrawl(const std::string& name);
     void log(const std::string& level, const std::string& msg, bool append_errno);
@@ -292,6 +292,12 @@ class ROSPACK_DECL Rosstackage
      *             crawling are written here.
      */
     void listDuplicates(std::vector<std::string>& dups);
+    /**
+     * @brief Identify duplicate stackages and provide their paths.  Forces crawl.
+     * @param dups Names of stackages that are found more than once while
+     *             crawling are mapped to the found paths of these packages.
+     */
+    void listDuplicatesWithPaths(std::map<std::string, std::vector<std::string> >& dups);
     /**
      * @brief Compute dependencies of a stackage (i.e., stackages that this
      *        stackages depends on).

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -532,12 +532,32 @@ Rosstackage::listDuplicates(std::vector<std::string>& dups)
 {
   dups.resize(dups_.size());
   int i = 0;
-  for(std::tr1::unordered_set<std::string>::const_iterator it = dups_.begin();
+  for(std::tr1::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
       it != dups_.end();
       ++it)
   {
-    dups[i] = (*it);
+    dups[i] = it->first;
     i++;
+  }
+}
+
+void
+Rosstackage::listDuplicatesWithPaths(std::map<std::string, std::vector<std::string> >& dups)
+{
+  dups.clear();
+  for(std::tr1::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
+      it != dups_.end();
+      ++it)
+  {
+    dups[it->first].resize(it->second.size());
+    int j = 0;
+    for(std::vector<std::string>::const_iterator jt = it->second.begin();
+        jt != it->second.end();
+        ++jt)
+    {
+      dups[it->first][j] = *jt;
+      j++;
+    }
   }
 }
 
@@ -1398,7 +1418,13 @@ Rosstackage::addStackage(const std::string& path)
 
   if(stackages_.find(stackage->name_) != stackages_.end())
   {
-    dups_.insert(stackage->name_);
+    if (dups_.find(stackage->name_) == dups_.end())
+    {
+      std::vector<std::string> dups;
+      dups.push_back(stackages_[stackage->name_]->path_);
+      dups_[stackage->name_] = dups;
+    }
+    dups_[stackage->name_].push_back(stackage->path_);
     return;
   }
 

--- a/src/rospack_cmdline.cpp
+++ b/src/rospack_cmdline.cpp
@@ -280,14 +280,20 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
       rp.logError( "invalid option(s) given");
       return false;
     }
-    std::vector<std::string> dups;
-    rp.listDuplicates(dups);
+    std::map<std::string, std::vector<std::string> > dups;
+    rp.listDuplicatesWithPaths(dups);
     // if there are dups, list-duplicates prints them and returns non-zero
-    for(std::vector<std::string>::const_iterator it = dups.begin();
+    for(std::map<std::string, std::vector<std::string> >::const_iterator it = dups.begin();
         it != dups.end();
         ++it)
     {
-      output.append(*it + "\n");
+      output.append(it->first + "\n");
+      for(std::vector<std::string>::const_iterator jt = it->second.begin();
+          jt != it->second.end();
+          ++jt)
+      {
+        output.append("- " + *jt + "\n");
+      }
     }
     return true;
   }


### PR DESCRIPTION
@tfoote @wjwwood Please review.

While the CLI command has been modified to also output the paths of the duplicate packages the existing C++ API has not been modified but a new function has been introduced.
