### PR TITLE
consider package as wet if package.xml exists

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -1379,15 +1379,15 @@ Rosstackage::addStackage(const std::string& path)
   Stackage* stackage = 0;
   fs::path dry_manifest_path = fs::path(path) / manifest_name_;
   fs::path wet_manifest_path = fs::path(path) / ROSPACKAGE_MANIFEST_NAME;
-  if(fs::is_regular_file(dry_manifest_path))
-  {
-    stackage = new Stackage(name, path, dry_manifest_path.string(), manifest_name_);
-  }
-  else if(fs::is_regular_file(wet_manifest_path))
+  if(fs::is_regular_file(wet_manifest_path))
   {
     stackage = new Stackage(name, path, wet_manifest_path.string(), ROSPACKAGE_MANIFEST_NAME);
     loadManifest(stackage);
     stackage->update_wet_information();
+  }
+  else if(fs::is_regular_file(dry_manifest_path))
+  {
+    stackage = new Stackage(name, path, dry_manifest_path.string(), manifest_name_);
   }
   else
   {


### PR DESCRIPTION
this is the patch to consider the package as wet if package.xml exists. current implementation regards the package as dry if manifest.xml, this means that if the package has both manifest.xml and package.xml then it consider the package as dry.
https://github.com/ros-infrastructure/rospkg/pull/55
