### PR TITLE
Only perform backquote substitution when needed

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008, Willow Garage, Inc., Morgan Quigley
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *   * Redistributions of source code must retain the above copyright notice,
@@ -208,8 +208,8 @@ class DirectoryCrawlRecord
     double start_time_;
     double crawl_time_;
     size_t start_num_pkgs_;
-    DirectoryCrawlRecord(std::string path, 
-                         double start_time, 
+    DirectoryCrawlRecord(std::string path,
+                         double start_time,
                          size_t start_num_pkgs) :
             path_(path),
             zombie_(false),
@@ -238,7 +238,7 @@ Rosstackage::Rosstackage(const std::string& manifest_name,
 {
 }
 
-void 
+void
 Rosstackage::logWarn(const std::string& msg,
                      bool append_errno)
 {
@@ -260,7 +260,7 @@ Rosstackage::getSearchPathFromEnv(std::vector<std::string>& sp)
   // ROS_ROOT is optional, and will be phased out
   if(rr)
   {
-    try 
+    try
     {
       if(fs::is_directory(rr))
         sp.push_back(rr);
@@ -283,7 +283,7 @@ Rosstackage::getSearchPathFromEnv(std::vector<std::string>& sp)
     #endif
 
     std::vector<std::string> rpp_strings;
-    boost::split(rpp_strings, rpp, 
+    boost::split(rpp_strings, rpp,
                  boost::is_any_of(path_delim),
                  boost::token_compress_on);
     for(std::vector<std::string>::const_iterator it = rpp_strings.begin();
@@ -401,13 +401,13 @@ Rosstackage::crawl(std::vector<std::string> search_path,
       p != search_paths_.end();
       ++p)
     crawlDetail(*p, force, 1, false, dummy, dummy2);
-  
+
   crawled_ = true;
 
   writeCache();
 }
 
-bool 
+bool
 Rosstackage::inStackage(std::string& name)
 {
   fs::path path;
@@ -457,7 +457,7 @@ Rosstackage::find(const std::string& name, std::string& path)
 }
 
 bool
-Rosstackage::contents(const std::string& name, 
+Rosstackage::contents(const std::string& name,
                       std::set<std::string>& packages)
 {
   Rospack rp2;
@@ -483,7 +483,7 @@ Rosstackage::contents(const std::string& name,
 }
 
 bool
-Rosstackage::contains(const std::string& name, 
+Rosstackage::contains(const std::string& name,
                       std::string& stack,
                       std::string& path)
 {
@@ -514,21 +514,21 @@ Rosstackage::contains(const std::string& name,
   return false;
 }
 
-void 
+void
 Rosstackage::list(std::set<std::pair<std::string, std::string> >& list)
 {
   for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
       it != stackages_.end();
       ++it)
   {
-    std::pair<std::string, std::string> item; 
-    item.first = it->first; 
-    item.second = it->second->path_; 
-    list.insert(item); 
+    std::pair<std::string, std::string> item;
+    item.first = it->first;
+    item.second = it->second->path_;
+    list.insert(item);
   }
 }
 
-void 
+void
 Rosstackage::listDuplicates(std::vector<std::string>& dups)
 {
   dups.resize(dups_.size());
@@ -650,7 +650,7 @@ Rosstackage::depsWhy(const std::string& from,
     logError(e.what());
     return true;
   }
-  output.append(std::string("Dependency chains from ") + 
+  output.append(std::string("Dependency chains from ") +
                 from + " to " + to + ":\n");
   for(std::list<std::list<Stackage*> >::const_iterator it = acc_list.begin();
       it != acc_list.end();
@@ -671,7 +671,7 @@ Rosstackage::depsWhy(const std::string& from,
 }
 
 bool
-Rosstackage::depsManifests(const std::string& name, bool direct, 
+Rosstackage::depsManifests(const std::string& name, bool direct,
                            std::vector<std::string>& manifests)
 {
   Stackage* stackage = findWithRecrawl(name);
@@ -696,7 +696,7 @@ Rosstackage::depsManifests(const std::string& name, bool direct,
 }
 
 bool
-Rosstackage::rosdeps(const std::string& name, bool direct, 
+Rosstackage::rosdeps(const std::string& name, bool direct,
                      std::set<std::string>& rosdeps)
 {
   Stackage* stackage = findWithRecrawl(name);
@@ -762,7 +762,7 @@ Rosstackage::_rosdeps(Stackage* stackage, std::set<std::string>& rosdeps, const 
 }
 
 bool
-Rosstackage::vcs(const std::string& name, bool direct, 
+Rosstackage::vcs(const std::string& name, bool direct,
                  std::vector<std::string>& vcs)
 {
   Stackage* stackage = findWithRecrawl(name);
@@ -809,7 +809,7 @@ Rosstackage::vcs(const std::string& name, bool direct,
   return true;
 }
 
-bool 
+bool
 Rosstackage::cpp_exports(const std::string& name, const std::string& type,
                      const std::string& attrib, bool deps_only,
                      std::vector<std::pair<std::string, bool> >& flags)
@@ -984,7 +984,7 @@ Rosstackage::reorder_paths(const std::string& paths, std::string& reordered)
   return true;
 }
 
-bool 
+bool
 Rosstackage::exports(const std::string& name, const std::string& lang,
                      const std::string& attrib, bool deps_only,
                      std::vector<std::string>& flags)
@@ -1017,7 +1017,7 @@ Rosstackage::exports(const std::string& name, const std::string& lang,
   return true;
 }
 
-bool 
+bool
 Rosstackage::exports_dry_package(Stackage* stackage, const std::string& lang,
                      const std::string& attrib,
                      std::vector<std::string>& flags)
@@ -1085,8 +1085,8 @@ Rosstackage::exports_dry_package(Stackage* stackage, const std::string& lang,
   return true;
 }
 
-bool 
-Rosstackage::plugins(const std::string& name, const std::string& attrib, 
+bool
+Rosstackage::plugins(const std::string& name, const std::string& attrib,
                      const std::string& top,
                      std::vector<std::string>& flags)
 {
@@ -1152,7 +1152,7 @@ Rosstackage::plugins(const std::string& name, const std::string& attrib,
 }
 
 bool
-Rosstackage::depsMsgSrv(const std::string& name, bool direct, 
+Rosstackage::depsMsgSrv(const std::string& name, bool direct,
                         std::vector<std::string>& gens)
 {
   Stackage* stackage = findWithRecrawl(name);
@@ -1167,11 +1167,11 @@ Rosstackage::depsMsgSrv(const std::string& name, bool direct,
         it != deps_vec.end();
         ++it)
     {
-      fs::path msg_gen = fs::path((*it)->path_) / 
-              MSG_GEN_GENERATED_DIR / 
+      fs::path msg_gen = fs::path((*it)->path_) /
+              MSG_GEN_GENERATED_DIR /
               MSG_GEN_GENERATED_FILE;
-      fs::path srv_gen = fs::path((*it)->path_) / 
-              SRV_GEN_GENERATED_DIR / 
+      fs::path srv_gen = fs::path((*it)->path_) /
+              SRV_GEN_GENERATED_DIR /
               SRV_GEN_GENERATED_FILE;
       if(fs::is_regular_file(msg_gen))
         gens.push_back(msg_gen.string());
@@ -1191,7 +1191,7 @@ Rosstackage::depsMsgSrv(const std::string& name, bool direct,
 // Rosstackage methods (private)
 /////////////////////////////////////////////////////////////
 
-void 
+void
 Rosstackage::log(const std::string& level,
                  const std::string& msg,
                  bool append_errno)
@@ -1370,7 +1370,7 @@ Rosstackage::profile(const std::vector<std::string>& search_path,
       char buf[16];
       snprintf(buf, sizeof(buf), "%.6f", (*it)->crawl_time_);
       if(length < 0 || i < length)
-        dirs.push_back(std::string(buf) + " " + 
+        dirs.push_back(std::string(buf) + " " +
                        ((*it)->zombie_ ? "* " : "  ") +
                        (*it)->path_);
       i++;
@@ -1541,7 +1541,7 @@ Rosstackage::crawlDetail(const std::string& path,
   {
     // Measure the elapsed time
     dcr->crawl_time_ = time_since_epoch() - dcr->start_time_;
-    // If the number of packages didn't change while crawling, 
+    // If the number of packages didn't change while crawling,
     // then this directory is a zombie
     if(stackages_.size() == dcr->start_num_pkgs_)
       dcr->zombie_ = true;
@@ -1556,7 +1556,7 @@ Rosstackage::loadManifest(Stackage* stackage)
 
   if(!stackage->manifest_.LoadFile(stackage->manifest_path_))
   {
-    std::string errmsg = std::string("error parsing manifest of package ") + 
+    std::string errmsg = std::string("error parsing manifest of package ") +
             stackage->name_ + " at " + stackage->manifest_path_;
     throw Exception(errmsg);
   }
@@ -1674,7 +1674,7 @@ Rosstackage::isSysPackage(const std::string& pkgname)
     return cache.find(pkgname)->second;
   }
 
-  initPython();  
+  initPython();
   PyGILState_STATE gstate = PyGILState_Ensure();
 
   static PyObject* pModule = 0;
@@ -1775,14 +1775,14 @@ Rosstackage::isSysPackage(const std::string& pkgname)
 }
 
 void
-Rosstackage::gatherDeps(Stackage* stackage, bool direct, 
+Rosstackage::gatherDeps(Stackage* stackage, bool direct,
                         traversal_order_t order,
                         std::vector<Stackage*>& deps,
                         bool no_recursion_on_wet)
 {
   std::tr1::unordered_set<Stackage*> deps_hash;
   std::vector<std::string> indented_deps;
-  gatherDepsFull(stackage, direct, order, 0, 
+  gatherDepsFull(stackage, direct, order, 0,
                  deps_hash, deps, false, indented_deps, no_recursion_on_wet);
 }
 
@@ -1905,11 +1905,11 @@ Rosstackage::getCachePath()
   {
     // Get the user's home directory by looking up the password entry based
     // on UID.  If that doesn't work, we fall back on examining $HOME,
-    // knowing that that can cause trouble when mixed with sudo (#2884).  
+    // knowing that that can cause trouble when mixed with sudo (#2884).
 #if defined(WIN32)
     char* home_drive = getenv("HOMEDRIVE");
     char* home_path = getenv("HOMEPATH");
-    if(home_drive && home_path) 
+    if(home_drive && home_path)
       cache_path = fs::path(home_drive) / fs::path(home_path) / fs::path(DOTROS_NAME);
 #else // UNIX
     char* home_path;
@@ -2024,7 +2024,7 @@ Rosstackage::writeCache()
     int fd = mkstemp(tmp_cache_path);
     if (fd < 0)
     {
-      fprintf(stderr, "[rospack] Unable to create temporary cache file %s: %s\n", 
+      fprintf(stderr, "[rospack] Unable to create temporary cache file %s: %s\n",
               tmp_cache_path, strerror(errno));
     }
     else
@@ -2033,7 +2033,7 @@ Rosstackage::writeCache()
 #endif
       if (!cache)
       {
-        fprintf(stderr, "[rospack] Unable open cache file %s: %s\n", 
+        fprintf(stderr, "[rospack] Unable open cache file %s: %s\n",
                 tmp_cache_path, strerror(errno));
       }
       else
@@ -2053,7 +2053,7 @@ Rosstackage::writeCache()
           remove(cache_path.c_str());
         if(rename(tmp_cache_path, cache_path.c_str()) < 0)
         {
-          fprintf(stderr, "[rospack] Error: failed to rename cache file %s to %s: %s\n", 
+          fprintf(stderr, "[rospack] Error: failed to rename cache file %s to %s: %s\n",
                   tmp_cache_path, cache_path.c_str(), strerror(errno));
         }
       }
@@ -2081,7 +2081,7 @@ Rosstackage::validateCache()
     if ((cache_max_age > 0.0) && (dt > cache_max_age))
       return NULL;
   }
-  // try to open it 
+  // try to open it
   FILE* cache = fopen(cache_path.c_str(), "r");
   if(!cache)
     return NULL; // it's not readable by us. sad.
@@ -2148,7 +2148,7 @@ Rosstackage::expandExportString(Stackage* stackage,
       i != std::string::npos;
       i = outstring.find(MANIFEST_PREFIX))
   {
-    outstring.replace(i, std::string(MANIFEST_PREFIX).length(), 
+    outstring.replace(i, std::string(MANIFEST_PREFIX).length(),
                       stackage->path_);
   }
 
@@ -2174,7 +2174,7 @@ Rosstackage::expandExportString(Stackage* stackage,
 
   // Remove embedded newlines
   std::string token("\n");
-  for (std::string::size_type s = cmd.find(token); 
+  for (std::string::size_type s = cmd.find(token);
        s != std::string::npos;
        s = cmd.find(token, s))
     cmd.replace(s,token.length(),std::string(" "));
@@ -2182,7 +2182,7 @@ Rosstackage::expandExportString(Stackage* stackage,
   FILE* p;
   if(!(p = popen(cmd.c_str(), "r")))
   {
-    std::string errmsg = 
+    std::string errmsg =
             std::string("failed to execute backquote expression ") +
             cmd + " in " +
             stackage->manifest_path_;
@@ -2202,7 +2202,7 @@ Rosstackage::expandExportString(Stackage* stackage,
     // Close the subprocess, checking exit status
     if(pclose(p) != 0)
     {
-      std::string errmsg = 
+      std::string errmsg =
               std::string("got non-zero exit status from executing backquote expression ") +
               cmd + " in " +
               stackage->manifest_path_;
@@ -2241,7 +2241,7 @@ Rosstackage::~Rosstackage()
   }
 }
 
-const char* 
+const char*
 Rospack::usage()
 {
   return "USAGE: rospack <command> [options] [package]\n"
@@ -2289,7 +2289,7 @@ Rosstack::Rosstack() :
 {
 }
 
-const char* 
+const char*
 Rosstack::usage()
 {
   return "USAGE: rosstack [options] <command> [stack]\n"
@@ -2319,14 +2319,14 @@ get_manifest_root(Stackage* stackage)
   TiXmlElement* ele = stackage->manifest_.RootElement();
   if(!ele)
   {
-    std::string errmsg = std::string("error parsing manifest of package ") + 
+    std::string errmsg = std::string("error parsing manifest of package ") +
             stackage->name_ + " at " + stackage->manifest_path_;
     throw Exception(errmsg);
   }
   return ele;
 }
 
-double 
+double
 time_since_epoch()
 {
 #if defined(WIN32)

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -2151,7 +2151,15 @@ Rosstackage::expandExportString(Stackage* stackage,
     outstring.replace(i, std::string(MANIFEST_PREFIX).length(), 
                       stackage->path_);
   }
-  
+
+  // skip substitution attempt when the string neither contains
+  // a dollar sign for $(command) and $envvar nor
+  // a backtick wrapping a command
+  if (outstring.find_first_of("$`") == std::string::npos)
+  {
+    return true;
+  }
+
   // Do backquote substitution.  E.g.,  if we find this string:
   //   `pkg-config --cflags gdk-pixbuf-2.0`
   // We replace it with the result of executing the command


### PR DESCRIPTION
This pull request has several goals.
1. fix an issue when using `pluginlib` in a `Xenomai` environment, for example through `ros_control`. In such an environment, calling `popen` can have disastrous consequences. While not preventing the call, the proposed fix removes unnecessary calls.
2. Improve speed of `pluginlib`. A call to `createInstance()` has been benchmarked to drop from around 2 seconds to 50 milliseconds with this fix on our local setup with a near-complete ROS hydro install + extra local packages.
3. Improve compatibility with non-POSIX systems, which have no bourne-compatible shell and thus cannot perform the substitution. This point should be further addressed by redesigning the substitution to match that of other components, e.g. launch files.

It is proposed against `groovy-devel` because it is very small and does not break API or ABI compatibility.
