### PR TITLE
Add missing run_depend on roslib

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <run_depend>python</run_depend>
   <run_depend>python-catkin-pkg</run_depend>
   <run_depend>python-rosdep</run_depend>
+  <run_depend>roslib</run_depend>
   <run_depend>tinyxml</run_depend>
 
   <test_depend>python-coverage</test_depend>


### PR DESCRIPTION
rospack doesn't generate any error if roslib isn't installed, but it is unable to find any packages without it

I would appreciate a backport to hydro and groovy for this one
