### PR TITLE
make error messages tool specific

### DIFF
--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -528,6 +528,12 @@ re-run the profile with --zombie-only
      */
     void logError(const std::string& msg,
                   bool append_errno = false);
+
+    /*
+     * @brief The manifest type.
+     * @return Either "package" or "stack".
+     */
+    virtual std::string get_manifest_type() { return ""; }
 };
 
 /**
@@ -546,6 +552,8 @@ class ROSPACK_DECL Rospack : public Rosstackage
      * @return Command-line usage for the rospack tool.
      */
     virtual const char* usage();
+
+    virtual std::string get_manifest_type();
 };
 
 /**
@@ -564,6 +572,8 @@ class ROSPACK_DECL Rosstack : public Rosstackage
      * @return Command-line usage for the rosstack tool.
      */
     virtual const char* usage();
+
+    virtual std::string get_manifest_type();
 };
 
 } // namespace rospack

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -1204,7 +1204,7 @@ Rosstackage::findWithRecrawl(const std::string& name)
       return stackages_[name];
   }
 
-  logError(std::string("stack/package ") + name + " not found");
+  logError(get_manifest_type() + " '" + name + "' not found");
   return NULL;
 }
 
@@ -1609,7 +1609,7 @@ Rosstackage::computeDepsInternal(Stackage* stackage, bool ignore_errors, const s
     {
       if(!ignore_errors)
       {
-        std::string errmsg = std::string("package/stack ") + stackage->name_ + " depends on itself";
+        std::string errmsg = get_manifest_type() + " '" + stackage->name_ + "' depends on itself";
         throw Exception(errmsg);
       }
     }
@@ -1626,7 +1626,7 @@ Rosstackage::computeDepsInternal(Stackage* stackage, bool ignore_errors, const s
       }
       else
       {
-        std::string errmsg = std::string("package/stack '") + stackage->name_ + "' depends on non-existent package '" + dep_pkgname + "' and rosdep claims that it is not a system dependency. Check the ROS_PACKAGE_PATH or try calling 'rosdep update'";
+        std::string errmsg = get_manifest_type() + " '" + stackage->name_ + "' depends on non-existent package '" + dep_pkgname + "' and rosdep claims that it is not a system dependency. Check the ROS_PACKAGE_PATH or try calling 'rosdep update'";
         throw Exception(errmsg);
       }
     }
@@ -2260,6 +2260,11 @@ Rospack::usage()
           " is used (if it contains a manifest.xml).\n\n";
 }
 
+std::string Rospack::get_manifest_type()
+{
+  return "package";
+}
+
 /////////////////////////////////////////////////////////////
 // Rosstack methods
 /////////////////////////////////////////////////////////////
@@ -2293,6 +2298,11 @@ Rosstack::usage()
           "    profile [--length=<length>] \n\n"
           " If [stack] is omitted, the current working directory\n"
           " is used (if it contains a stack.xml).\n\n";
+}
+
+std::string Rosstack::get_manifest_type()
+{
+  return "stack";
 }
 
 TiXmlElement*

--- a/src/rospack_cmdline.cpp
+++ b/src/rospack_cmdline.cpp
@@ -222,7 +222,7 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
   {
     if(!package.size())
     {
-      rp.logError( "no package/stack given");
+      rp.logError(std::string("no ") + rp.get_manifest_type() + " given");
       return false;
     }
     if(target.size() || top.size() || length_str.size() ||
@@ -354,7 +354,7 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
   {
     if(!package.size())
     {
-      rp.logError( "no package/stack given");
+      rp.logError(std::string("no ") + rp.get_manifest_type() + " given");
       return false;
     }
     if(target.size() || top.size() || length_str.size() ||
@@ -377,7 +377,7 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
   {
     if(!package.size())
     {
-      rp.logError( "no package/stack given");
+      rp.logError(std::string("no ") + rp.get_manifest_type() + " given");
       return false;
     }
     if(target.size() || top.size() || length_str.size() ||
@@ -434,7 +434,7 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
   {
     if(!package.size())
     {
-      rp.logError( "no package/stack given");
+      rp.logError(std::string("no ") + rp.get_manifest_type() + " given");
       return false;
     }
     if(target.size() || top.size() || length_str.size() ||
@@ -457,7 +457,7 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
   {
     if(!package.size() || !target.size())
     {
-      rp.logError( "no package/stack or target given");
+      rp.logError(std::string("no ") + rp.get_manifest_type() + " or target given");
       return false;
     }
     if(top.size() || length_str.size() ||
@@ -529,7 +529,7 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
   {
     if(!package.size())
     {
-      rp.logError( "no package/stack given");
+      rp.logError(std::string("no ") + rp.get_manifest_type() + " given");
       return false;
     }
     if(target.size() || top.size() || length_str.size() ||


### PR DESCRIPTION
Error messages now output either `package` or `stack` rather then `package/stack`.
