### PR TITLE
find library for exact python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(rospack)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules)
 find_package(Boost REQUIRED COMPONENTS filesystem program_options system)
+set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 set(PythonLibs_FIND_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 find_package(PythonLibs REQUIRED)
 find_package(TinyXML REQUIRED)


### PR DESCRIPTION
Necessary to work with Python 3.4 on Trusty since it is not in the CMake provided file containing only Python version number up to 3.3.
