### PR TITLE
Fix find_package(PythonLibs ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,7 @@ project(rospack)
 find_package(catkin REQUIRED COMPONENTS cmake_modules)
 find_package(Boost REQUIRED COMPONENTS filesystem program_options system)
 set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
-set(PythonLibs_FIND_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 find_package(TinyXML REQUIRED)
 
 catkin_package(


### PR DESCRIPTION
The version should be passed as argument, not by setting PythonLibs_FIND_VERSION.

This breaks builds in recentely released cmake 3.0.0 it seems: http://answers.ros.org/question/178375/linking-camera_info_manager-fails-on-osx/

This change should also be backported to groovy/hydro.
