### PR TITLE
Include absolute library path args in libs-only-l results, instead of libs-only-other

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -870,7 +870,16 @@ Rosstackage::cpp_exports(const std::string& name, const std::string& type,
         }
 
         PyObject* pArgs = PyTuple_New(2);
-        PyObject* pOpt = PyUnicode_FromString(type.c_str());
+        PyObject* pOpt;
+        // If we're asked to do --libs-only-l, --libs-only-L, or
+        // --libs-only-other, then just get --libs, and count on rospack's
+        // post-processing to pull out the right stuff.
+        if((type == "--libs-only-l") ||
+           (type == "--libs-only-L") ||
+           (type == "--libs-only-other"))
+          pOpt = PyUnicode_FromString("--libs");
+        else
+          pOpt = PyUnicode_FromString(type.c_str());
         PyTuple_SetItem(pArgs, 0, pOpt);
         PyObject* pPkg = PyUnicode_FromString((*it)->name_.c_str());
         PyTuple_SetItem(pArgs, 1, pPkg);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -120,9 +120,17 @@ parse_compiler_flags(const std::string& instring,
       }
     }
     // Special case: if we're told to look for -l, then also find *.a
-    else if(it->size() > 2 &&
-            (*it)[0] == '/' &&
-            it->substr(it->size()-2) == ".a")
+    // or *.so or *.dylib
+    else if((token == "-l") &&
+            ((it->size() > 2 &&
+              (*it)[0] == '/' &&
+              (it->substr(it->size()-2) == ".a")) ||
+             (it->size() > 3 &&
+              (*it)[0] == '/' &&
+              (it->substr(it->size()-3) == ".so")) ||
+             (it->size() > 6 &&
+              (*it)[0] == '/' &&
+              (it->substr(it->size()-6) == ".dylib"))))
     {
       if(select)
       {

--- a/test/catkin/wet_package/lib/pkgconfig/wet_package.pc
+++ b/test/catkin/wet_package/lib/pkgconfig/wet_package.pc
@@ -1,0 +1,6 @@
+Name: wet_package
+Description: Description of wet_package
+Version: 0.0.0
+Cflags: -I/opt/ros/jade/include -I/usr/include
+Libs: -L/opt/ros/jade/lib -lroscpp -foo -lpthread /usr/lib/x86_64-linux-gnu/libboost_signals.so -lbat /usr/lib/x86_64-linux-gnu/libboost_filesystem.so /usr/lib/x86_64-linux-gnu/libboost_system.so bar /foo/bar.whatever -Lsomething /bat/mylib.dylib lib.dylib foo.so bat.a /lib/libgcc.a -L/foo/bar
+Requires:

--- a/test/catkin/wet_package/package.xml
+++ b/test/catkin/wet_package/package.xml
@@ -1,0 +1,12 @@
+<package>
+  <name>wet_package</name>
+  <version>0.0.0</version>
+  <description>
+    A wet package.
+  </description>
+  <maintainer email="gerkey@osrfoundation.org">Brian Gerkey</maintainer>
+  <license>BSD</license>
+
+  <url>http://ros.org/wiki/rospack</url>
+  <author>Brian Gerkey</author>
+</package>

--- a/test/test/utest.py.in
+++ b/test/test/utest.py.in
@@ -865,3 +865,26 @@ class RospackTestCase(unittest.TestCase):
         status_code, stdout, stderr = self._run_rospack(rpp, 'nonexistentpackage', 'find')
         self.assertNotEquals(0, status_code)
         self.assertNotEquals(0, len(stderr))
+
+    # Test that absolute library paths are properly parsed from .pc files
+    # provided in wet packages.
+    def test_abspath_wet_package(self):
+        rpp = os.path.abspath('catkin')
+        env = os.environ.copy()
+        os.environ['PKG_CONFIG_PATH'] = \
+          os.path.abspath('catkin/wet_package/lib/pkgconfig')
+        # libs-only-l should give us the -l args and the /*.[a,so,dylib] args
+        status_code, stdout, stderr = self._run_rospack(rpp, 'wet_package', 'libs-only-l')
+        self.assertEquals(0, status_code)
+        self.assertEquals(0, len(stderr))
+        self.assertEquals('roscpp pthread /usr/lib/x86_64-linux-gnu/libboost_signals.so bat /usr/lib/x86_64-linux-gnu/libboost_filesystem.so /usr/lib/x86_64-linux-gnu/libboost_system.so /bat/mylib.dylib /lib/libgcc.a', stdout)
+        # libs-only-L should give the -L args
+        status_code, stdout, stderr = self._run_rospack(rpp, 'wet_package', 'libs-only-L')
+        self.assertEquals(0, status_code)
+        self.assertEquals(0, len(stderr))
+        self.assertEquals('/opt/ros/jade/lib something /foo/bar', stdout)
+        # libs-only-other should give everything else
+        status_code, stdout, stderr = self._run_rospack(rpp, 'wet_package', 'libs-only-other')
+        self.assertEquals(0, status_code)
+        self.assertEquals(0, len(stderr))
+        self.assertEquals('-foo bar /foo/bar.whatever lib.dylib foo.so bat.a', stdout)


### PR DESCRIPTION
~~(Not ready to merge; I'm working on a test case.)~~  Test added in 2754668.

This fix is intended to address, in part, ros/catkin#694.  Catkin will also need to be modified to drop the `-l:` prefix from absolute library paths in `Libs:` lines in the `.pc` files that it generates.

There are two changes here:
- When asked for `libs-only-*`, ask `pkg-config` for the more general `--libs`, which will give us the entire exported string.  Rely on rospack's existing parsing routine to pull out what's needed.
- When parsing the result from `libs-only-l`, include non-prefixed absolute paths to shared libraries along with the lib names that have a `-l` prefix.
