### PR TITLE
dramatic performance boost for consecutive rospack calls [backport to indigo]

### DIFF
--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -152,6 +152,7 @@ class ROSPACK_DECL Rosstackage
     std::tr1::unordered_map<std::string, Stackage*> stackages_;
     Stackage* findWithRecrawl(const std::string& name);
     void log(const std::string& level, const std::string& msg, bool append_errno);
+    void clearStackages();
     void addStackage(const std::string& path);
     void crawlDetail(const std::string& path,
                      bool force,

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -243,6 +243,23 @@ Rosstackage::Rosstackage(const std::string& manifest_name,
 {
 }
 
+Rosstackage::~Rosstackage()
+{
+  clearStackages();
+}
+
+void Rosstackage::clearStackages()
+{
+  for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+      it != stackages_.end();
+      ++it)
+  {
+    delete it->second;
+  }
+  stackages_.clear();
+  dups_.clear();
+}
+
 void
 Rosstackage::logWarn(const std::string& msg,
                      bool append_errno)
@@ -350,14 +367,7 @@ Rosstackage::crawl(std::vector<std::string> search_path,
       return;
   }
 
-
-  std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
-  while(it != stackages_.end())
-  {
-    delete it->second;
-    it = stackages_.erase(it);
-  }
-  dups_.clear();
+  clearStackages();
   search_paths_ = search_path;
 
   std::vector<DirectoryCrawlRecord*> dummy;
@@ -1941,6 +1951,7 @@ Rosstackage::readCache()
   FILE* cache = validateCache();
   if(cache)
   {
+    clearStackages();
     char linebuf[30000];
     for(;;)
     {
@@ -2206,16 +2217,6 @@ Rospack::Rospack() :
                     ROSPACK_NAME,
                     MANIFEST_TAG_PACKAGE)
 {
-}
-
-Rosstackage::~Rosstackage()
-{
-  for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
-      it != stackages_.end();
-      ++it)
-  {
-    delete it->second;
-  }
 }
 
 const char*

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -328,27 +328,13 @@ Rosstackage::isStackage(const std::string& path)
   return false;
 }
 
-static bool sameSearchPaths(const std::vector<std::string> &path1,
-                            const std::vector<std::string> &path2)
-{
-  if(path1.size() != path2.size())
-    return false;
-
-  for(unsigned int i=0, end=path1.size(); i != end; ++i)
-  {
-    if(path1[i] != path2[i])
-      return false;
-  }
-  return true;
-}
-
 void
 Rosstackage::crawl(std::vector<std::string> search_path,
                    bool force)
 {
   if(!force)
   {
-    bool same_search_paths = sameSearchPaths(search_path, search_paths_);
+    bool same_search_paths = (search_path == search_paths_);
 
     // if search paths differ, try to reading the cache corresponding to the new paths
     if(!same_search_paths && readCache())

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -328,14 +328,30 @@ Rosstackage::isStackage(const std::string& path)
   return false;
 }
 
+static bool sameSearchPaths(const std::vector<std::string> &path1,
+                            const std::vector<std::string> &path2)
+{
+  if(path1.size() != path2.size())
+    return false;
+
+  for(unsigned int i=0, end=path1.size(); i != end; ++i)
+  {
+    if(path1[i] != path2[i])
+      return false;
+  }
+  return true;
+}
+
 void
 Rosstackage::crawl(std::vector<std::string> search_path,
                    bool force)
 {
   if(!force)
   {
-    // read the cache only once (when search_paths_ is still empty)
-    if(search_paths_.empty() && readCache())
+    bool same_search_paths = sameSearchPaths(search_path, search_paths_);
+
+    // if search paths differ, try to reading the cache corresponding to the new paths
+    if(!same_search_paths && readCache())
     {
       // If the cache was valid, then the paths in the cache match the ones
       // we've been asked to crawl.  Store them, so that later, methods
@@ -344,26 +360,8 @@ Rosstackage::crawl(std::vector<std::string> search_path,
       return;
     }
 
-    if(crawled_)
-    {
-      bool same_paths = true;
-      if(search_paths_.size() != search_path.size())
-        same_paths = false;
-      else
-      {
-        for(unsigned int i=0; i<search_paths_.size(); i++)
-        {
-          if(search_paths_[i] != search_path[i])
-          {
-            same_paths = false;
-            break;
-          }
-        }
-      }
-
-      if(same_paths)
-        return;
-    }
+    if(crawled_ && same_search_paths)
+      return;
   }
 
 

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -334,16 +334,13 @@ Rosstackage::crawl(std::vector<std::string> search_path,
 {
   if(!force)
   {
-    if(readCache())
+    // read the cache only once (when search_paths_ is still empty)
+    if(search_paths_.empty() && readCache())
     {
       // If the cache was valid, then the paths in the cache match the ones
       // we've been asked to crawl.  Store them, so that later, methods
       // like find() can refer to them when recrawling.
-      search_paths_.clear();
-      for(std::vector<std::string>::const_iterator it = search_path.begin();
-          it != search_path.end();
-          ++it)
-        search_paths_.push_back(*it);
+      search_paths_ = search_path;
       return;
     }
 

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -367,6 +367,8 @@ Rosstackage::crawl(std::vector<std::string> search_path,
       return;
   }
 
+  // We're about to crawl, so clear internal storage (in case this is the second
+  // run in this process).
   clearStackages();
   search_paths_ = search_path;
 
@@ -1951,6 +1953,8 @@ Rosstackage::readCache()
   FILE* cache = validateCache();
   if(cache)
   {
+    // We're about to read from the cache, so clear internal storage (in case this is
+    // the second run in this process).
     clearStackages();
     char linebuf[30000];
     for(;;)

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -358,11 +358,7 @@ Rosstackage::crawl(std::vector<std::string> search_path,
     it = stackages_.erase(it);
   }
   dups_.clear();
-  search_paths_.clear();
-  for(std::vector<std::string>::const_iterator it = search_path.begin();
-      it != search_path.end();
-      ++it)
-    search_paths_.push_back(*it);
+  search_paths_ = search_path;
 
   std::vector<DirectoryCrawlRecord*> dummy;
   std::tr1::unordered_set<std::string> dummy2;

--- a/src/rospack_backcompat.cpp
+++ b/src/rospack_backcompat.cpp
@@ -40,7 +40,8 @@ namespace rospack
 int
 ROSPack::run(int argc, char** argv)
 {
-  rospack::Rospack rp;
+  // allow caching of results between calls (of same process)
+  static rospack::Rospack rp;
   output_.clear();
   bool success = rospack::rospack_run(argc, argv, rp, output_);
   if(!success)

--- a/test/test/utest.cpp
+++ b/test/test/utest.cpp
@@ -209,14 +209,9 @@ TEST(rospack, env_change)
   setenv("ROS_PACKAGE_PATH", rr.c_str(), 1);
   ret = rp.run(std::string("list-names"));
   EXPECT_EQ(ret, 0);
-  output_list.clear();
   output = rp.getOutput();
-  std::cerr << "output: " << output << std::endl;
   boost::trim(output);
-  boost::split(output_list, output, boost::is_any_of("\n"));
-  // Check that we get back the right list of packages (which could be in any
-  // order).
-  EXPECT_EQ(output_list.size(), 0);
+  EXPECT_EQ(output, std::string());
 
   // Reset old path, for other tests
   setenv("ROS_PACKAGE_PATH", oldrpp, 1);

--- a/test/test/utest.cpp
+++ b/test/test/utest.cpp
@@ -126,6 +126,65 @@ TEST(rospack, deduplicate_tokens)
   ASSERT_EQ(truth, output);
 }
 
+// Test that env var changes between runs still produce the right results.
+/*
+TEST(rospack, env_change)
+{
+  // Get old path for resetting later, to avoid cross-talk with other tests
+  char* oldrpp = getenv("ROS_PACKAGE_PATH");
+
+  char buf[1024];
+  std::string rr = std::string(getcwd(buf, sizeof(buf))) + "/test2";
+  setenv("ROS_PACKAGE_PATH", rr.c_str(), 1);
+  std::vector<std::string> test2_pkgs;
+  test2_pkgs.push_back("precedence1");
+  test2_pkgs.push_back("precedence2");
+  test2_pkgs.push_back("precedence3");
+  test2_pkgs.push_back("roslang");
+
+  rospack::ROSPack rp;
+
+  std::string output;
+  int ret = rp.run(std::string("list-names"));
+  EXPECT_EQ(ret, 0);
+  std::vector<std::string> output_list;
+  output = rp.getOutput();
+  boost::trim(output);
+  boost::split(output_list, output, boost::is_any_of("\n"));
+  // Check that we get back the right list of packages (which could be in any
+  // order).
+  EXPECT_EQ(output_list.size(), test2_pkgs.size());
+  for(std::vector<std::string>::const_iterator it = output_list.begin();
+      it != output_list.end();
+      ++it)
+  {
+    bool found = false;
+    for(std::vector<std::string>::const_iterator it2 = test2_pkgs.begin();
+        it2 != test2_pkgs.end();
+        ++it2)
+    {
+      EXPECT_FALSE(found);
+      if(*it == *it2)
+        found = true;
+    }
+    EXPECT_TRUE(found);
+  }
+
+  ret = rp.run(std::string("list"));
+  EXPECT_EQ(ret, 0);
+  output = rp.getOutput();
+  boost::trim(output);
+  boost::split(output_list, output, boost::is_any_of("\n"));
+  EXPECT_EQ((int)output_list.size(), 4);
+  std::vector<std::string> path_name;
+  boost::split(path_name, output_list[0], boost::is_any_of(" "));
+  EXPECT_EQ((int)path_name.size(), 2);
+
+  // Reset old path, for other tests
+  setenv("ROS_PACKAGE_PATH", oldrpp, 1);
+}
+*/
+
 int main(int argc, char **argv)
 {
   // Quiet some warnings

--- a/test/test/utest.cpp
+++ b/test/test/utest.cpp
@@ -127,23 +127,21 @@ TEST(rospack, deduplicate_tokens)
 }
 
 // Test that env var changes between runs still produce the right results.
-/*
 TEST(rospack, env_change)
 {
   // Get old path for resetting later, to avoid cross-talk with other tests
   char* oldrpp = getenv("ROS_PACKAGE_PATH");
+  rospack::ROSPack rp;
 
+  // Case 1: RPP=/test2
   char buf[1024];
   std::string rr = std::string(getcwd(buf, sizeof(buf))) + "/test2";
   setenv("ROS_PACKAGE_PATH", rr.c_str(), 1);
-  std::vector<std::string> test2_pkgs;
-  test2_pkgs.push_back("precedence1");
-  test2_pkgs.push_back("precedence2");
-  test2_pkgs.push_back("precedence3");
-  test2_pkgs.push_back("roslang");
-
-  rospack::ROSPack rp;
-
+  std::vector<std::string> test_pkgs;
+  test_pkgs.push_back("precedence1");
+  test_pkgs.push_back("precedence2");
+  test_pkgs.push_back("precedence3");
+  test_pkgs.push_back("roslang");
   std::string output;
   int ret = rp.run(std::string("list-names"));
   EXPECT_EQ(ret, 0);
@@ -153,37 +151,76 @@ TEST(rospack, env_change)
   boost::split(output_list, output, boost::is_any_of("\n"));
   // Check that we get back the right list of packages (which could be in any
   // order).
-  EXPECT_EQ(output_list.size(), test2_pkgs.size());
+  EXPECT_EQ(output_list.size(), test_pkgs.size());
   for(std::vector<std::string>::const_iterator it = output_list.begin();
       it != output_list.end();
       ++it)
   {
     bool found = false;
-    for(std::vector<std::string>::const_iterator it2 = test2_pkgs.begin();
-        it2 != test2_pkgs.end();
+    for(std::vector<std::string>::const_iterator it2 = test_pkgs.begin();
+        it2 != test_pkgs.end();
         ++it2)
     {
-      EXPECT_FALSE(found);
       if(*it == *it2)
+      {
+        EXPECT_FALSE(found);
         found = true;
+      }
     }
     EXPECT_TRUE(found);
   }
 
-  ret = rp.run(std::string("list"));
+  // Case 2: RPP=/test3
+  rr = std::string(getcwd(buf, sizeof(buf))) + "/test3";
+  setenv("ROS_PACKAGE_PATH", rr.c_str(), 1);
+  test_pkgs.clear();
+  test_pkgs.push_back("precedence1");
+  test_pkgs.push_back("precedence2");
+  test_pkgs.push_back("precedence3");
+  ret = rp.run(std::string("list-names"));
   EXPECT_EQ(ret, 0);
+  output_list.clear();
   output = rp.getOutput();
   boost::trim(output);
   boost::split(output_list, output, boost::is_any_of("\n"));
-  EXPECT_EQ((int)output_list.size(), 4);
-  std::vector<std::string> path_name;
-  boost::split(path_name, output_list[0], boost::is_any_of(" "));
-  EXPECT_EQ((int)path_name.size(), 2);
+  // Check that we get back the right list of packages (which could be in any
+  // order).
+  EXPECT_EQ(output_list.size(), test_pkgs.size());
+  for(std::vector<std::string>::const_iterator it = output_list.begin();
+      it != output_list.end();
+      ++it)
+  {
+    bool found = false;
+    for(std::vector<std::string>::const_iterator it2 = test_pkgs.begin();
+        it2 != test_pkgs.end();
+        ++it2)
+    {
+      if(*it == *it2)
+      {
+        EXPECT_FALSE(found);
+        found = true;
+      }
+    }
+    EXPECT_TRUE(found);
+  }
+
+  // Case 3: RPP=/test_empty
+  rr = std::string(getcwd(buf, sizeof(buf))) + "/test_empty";
+  setenv("ROS_PACKAGE_PATH", rr.c_str(), 1);
+  ret = rp.run(std::string("list-names"));
+  EXPECT_EQ(ret, 0);
+  output_list.clear();
+  output = rp.getOutput();
+  std::cerr << "output: " << output << std::endl;
+  boost::trim(output);
+  boost::split(output_list, output, boost::is_any_of("\n"));
+  // Check that we get back the right list of packages (which could be in any
+  // order).
+  EXPECT_EQ(output_list.size(), 0);
 
   // Reset old path, for other tests
   setenv("ROS_PACKAGE_PATH", oldrpp, 1);
 }
-*/
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Consecutive calls to the rospack library, e.g. `ros::package::getPath()`, from within the same process recrawled the `ROS_PACKAGE_PATH` all the time, because the appropriate rospack instances were created again and again.
This PR (going in line with a similar PR on roslib) improves things in two respects:
- a static `rospack::Rospack` instance is used in `ROSPack::run()`, thus re-using the same instance for all consecutive calls
- in `Rosstackage::crawl()` the cache is loaded only once at the beginning, when `search_paths_` is still empty

The following simple test program (doing 3000 calls to `getPath()`) performs 160 times faster:

```
time ./foo
real    0m0.264s
user    0m0.251s
sys     0m0.012s

time ./foo
real    0m49.456s
user    0m42.500s
sys     0m6.840s
```

``` cpp
#include <ros/package.h>
int main(int argc, char *argv[]) {
    for (int i=0; i<3000; ++i) {
        ros::package::getPath("roscpp");
    }
}
```
