### PR TITLE
undef symbols to avoid warning

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -73,6 +73,9 @@
 
 /* re-define some String functions for python 2.x */
 #if PY_VERSION_HEX < 0x03000000
+#undef PyBytes_AsString
+#undef PyUnicode_AsUTF8
+#undef PyUnicode_FromString
 #define PyBytes_AsString PyString_AsString
 #define PyUnicode_AsUTF8 PyString_AsString
 #define PyUnicode_FromString PyString_FromString


### PR DESCRIPTION
undef symbols before defining them to avoid preprocessor warnings in the case that they were already defined.

I'm currently only getting only getting a warning on one symbol:

```
/home/gerkey/code/rospack-caching/src/rospack/src/rospack.cpp:78:0: warning: "PyUnicode_FromString" redefined [enabled by default]
 #define PyUnicode_FromString PyString_FromString
 ^
In file included from /usr/include/python2.7/Python.h:85:0,
                 from /home/gerkey/code/rospack-caching/src/rospack/src/rospack.cpp:72:
/usr/include/python2.7/unicodeobject.h:281:0: note: this is the location of the previous definition
 # define PyUnicode_FromString PyUnicodeUCS4_FromString
 ^
```

but we might as well undef them all.
