### PR TITLE
Return 1 if the package name in rospack plugins can not be found

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -1288,7 +1288,10 @@ Rosstackage::depsOnDetail(const std::string& name, bool direct,
   // No recrawl here, because depends-on always forces a crawl at the
   // start.
   if(!stackages_.count(name))
-    logWarn(std::string("no such package ") + name);
+  {
+    logError(std::string("no such package ") + name);
+    return false;
+  }
   try
   {
     for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();


### PR DESCRIPTION
@hugomatic and I found out that if a user passes an invalid package name to `rospack plugins`, the error code is still 0:

``` shell
$ rospack plugins --attrib=plugin pluginliba; echo $?
[rospack] Warning: no such package pluginliba
0
```

being analogous to `ls`:

``` shell
$ ls invalid_path ; echo $?
ls: cannot access invalid_path: No such file or directory
2
```

This PR changes the behavior to return 1:

``` shell
$ rospack plugins --attrib=plugin pluginliba; echo $?
[rospack] Warning: no such package pluginliba
1
```
