### PR TITLE
fixed unittest

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -358,11 +358,7 @@ Rosstackage::crawl(std::vector<std::string> search_path,
     it = stackages_.erase(it);
   }
   dups_.clear();
-  search_paths_.clear();
-  for(std::vector<std::string>::const_iterator it = search_path.begin();
-      it != search_path.end();
-      ++it)
-    search_paths_.push_back(*it);
+  search_paths_ = search_path;
 
   std::vector<DirectoryCrawlRecord*> dummy;
   std::tr1::unordered_set<std::string> dummy2;

--- a/test/test/utest.cpp
+++ b/test/test/utest.cpp
@@ -209,14 +209,9 @@ TEST(rospack, env_change)
   setenv("ROS_PACKAGE_PATH", rr.c_str(), 1);
   ret = rp.run(std::string("list-names"));
   EXPECT_EQ(ret, 0);
-  output_list.clear();
   output = rp.getOutput();
-  std::cerr << "output: " << output << std::endl;
   boost::trim(output);
-  boost::split(output_list, output, boost::is_any_of("\n"));
-  // Check that we get back the right list of packages (which could be in any
-  // order).
-  EXPECT_EQ(output_list.size(), 0);
+  EXPECT_EQ(output, std::string());
 
   // Reset old path, for other tests
   setenv("ROS_PACKAGE_PATH", oldrpp, 1);


### PR DESCRIPTION
@gerkey You probably already found the issue with the unit test:

`boost::split` of an empty string returns a list containing an empty string, not an empty list.
