### PR TITLE
[In progress] Add license feature

### DIFF
--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -285,6 +285,12 @@ class ROSPACK_DECL Rosstackage
                   std::string& path);
 
     /**
+     * @brief List license(s) of a stackage whose name is passed.
+     * @param deps Names of the depended stackages.
+     * @param licenses Pairs of (package name, license(s)).
+     */
+    void licenses(std::vector<std::string>& deps, std::set<std::pair<std::string, std::vector<std::string> > >& licenses);
+    /**
      * @brief List names and paths of all stackages.
      * @param list Pairs of (name,path) are written here.
      */

--- a/test/test/utest.py.in
+++ b/test/test/utest.py.in
@@ -228,6 +228,7 @@ class RospackTestCase(unittest.TestCase):
         self.rospack_fail(None, "deps --length=10")
         self.rospack_fail(None, "deps --zombie-only")
         self.rospack_fail(None, "profile --deps-only")
+        self.rospack_fail(None, "profile --license")
 
     def test_ros_cache_timeout(self):
         env = os.environ.copy()
@@ -300,6 +301,7 @@ class RospackTestCase(unittest.TestCase):
 
     def test_no_package_allowed_bad(self):
         self.rospack_fail("deps", "profile")
+        self.rospack_fail("deps", "license")
         self.rospack_fail("deps", "list")
         self.rospack_fail("deps", "list-names")
         self.rospack_fail("deps", "list-duplicates")


### PR DESCRIPTION
I open a PR to ask for comments although work is in progress.
I'm adding a command that returns the license of the dependency of a package.

The example looks as the following (I know this needs lots of polish):

```
$ rospack depends1 navfn
costmap_2d
geometry_msgs
nav_core
nav_msgs
pcl_conversions
pcl_ros
pluginlib
rosconsole
roscpp
tf
visualization_msgs

$ rospack license navfn
costmap_2d  BSD 
geometry_msgs   BSD 
nav_core    BSD 
nav_msgs    BSD 
pcl_conversions BSD 
pcl_ros BSD 
pluginlib   BSD Boost Software License 
rosconsole  BSD 
roscpp  BSD 
tf  BSD 
visualization_msgs  BSD 
```

Below is just my note.

Requirement
- Implemented as upstream as possible --> so `rospack` should be a good place?
- Multi-platform, not just on Ubuntu  --> Need ROS/Catkin specific tool that can handle `package.xml` where the license is declared?
- Must work with all ROS packages whether it's deb or source.
- Make it as both 1) public API and 2) commandline option.
- No breakage for existing api.

Research for existing tools
- `debtree`: Great tool for speculating pkg dependency, with commanline output and even GUi output. We can aim its output.
- `ldd`: Only works with libs.
- `Dependency Walker`: Only works on MS Windows.
- `binscan`: only works for binaries.
- `ELF Library Viewer`: only works for ELF executables.
