### PR TITLE
Add license field in Stackage class.

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -147,6 +147,8 @@ class Stackage
     std::string manifest_path_;
     // \brief filename of the stackage manifest
     std::string manifest_name_;
+    // \brief package's license with a support for multi-license.
+    std::vector<std::string> licenses_;
     // \brief have we already loaded the manifest?
     bool manifest_loaded_;
     // \brief TinyXML structure, filled in during parsing
@@ -181,6 +183,12 @@ class Stackage
       {
         name_ = el->GetText();
         break;
+      }
+      // Get license texts, where there may be multiple elements for.
+      std::string tagname_license = "license";
+      for(TiXmlElement* el = root->FirstChildElement(tagname_license); el; el = el->NextSiblingElement(tagname_license ))
+      {
+        licenses_.push_back(el->GetText());
       }
       // check if package is a metapackage
       for(TiXmlElement* el = root->FirstChildElement("export"); el; el = el->NextSiblingElement("export"))

--- a/test/benchmark/measure_performace.sh
+++ b/test/benchmark/measure_performace.sh
@@ -1,0 +1,45 @@
+# Copyright (C) 2016, Open Source Robotics Foundation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the names of Stanford University or Open Source Robotics Foundation. nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+function iterate_command {
+  command=${1:-"rospack profile"};
+  num_iteration=${2:-10000};
+  for i in $(seq 1 ${num_iteration}); do
+    echo "${i}th iteration.";
+    $command;
+  done
+}
+
+function measure_performance {
+  command=${1:-"rospack profile"};
+  num_iteration=${2:-100000};
+  output_filename=${3:-"straceResult_${command// /-}_${num_iteration}_`date +%Y%m%d%H%M%S`.log"};
+  echo "Command to be measured: ${command}";
+
+  export ROS_CACHE_TIMEOUT=0.0 # Needed to not use cache.
+
+  # strace doesn't easily call a function. http://unix.stackexchange.com/questions/339173/strace-not-finding-shell-function-with-cant-stat-error
+  strace -o ${output_filename} -c -Ttt bash -c "$(typeset -f iterate_command); iterate_command '${command}' $num_iteration";
+}


### PR DESCRIPTION
`Rosstackage` class does probably not necessarily map exactly all the elements defined in `package.xml`, but from the api perspective, it'll be beneficial to be able to access more elements through this class so that client codes won't have to parse xml when needed (here this is related to #65).

Possible downside is that whenever `rospack` crawls it could take longer since more parsing happens (though I haven't tested), and for particularly usecases where license info is not needed this added info is simply a waste of time. I'm not sure how critical rospack's performance is, so I appreciate opinions.