### PR TITLE
[Jade] Add some temporary deps* function to public.

### DIFF
--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -335,6 +335,28 @@ class ROSPACK_DECL Rosstackage
      *                  that the given stackage depends on is written here.
      * @return True if the manifest list was computed, false otherwise.
      */
+     bool depsDetail_pub(const std::string& name, bool direct, std::vector<Stackage*>& deps);
+     /**
+     * @brief NOTE: This function is added only for the backward compatibility purpose; in the next distro-branch this will be deleted.
+     *
+     *        Compute reverse dependencies of a stackage (i.e., stackages
+     *        that depend on this stackage), taking and returning stackage objects. Forces crawl.
+     * @param name The stackage to work on.
+     * @param direct If true, then compute only direct dependencies.  If
+     *               false, then compute full (including indirect) dependencies.
+     * @param deps List of Stackage objects. If dependencies are computed, then they're written here in stackage objects.
+     * @return True if dependencies were computed, false otherwise.
+     */
+    bool depsOnDetail_pub(const std::string& name, bool direct,
+                      std::vector<Stackage*>& deps, bool ignore_missing=false);
+    /**
+     * @brief NOTE: This function is added only for the backward compatibility purpose; in the next distro-branch this will be deleted.
+     *
+     *              List the manifests of a stackage's dependencies.  Used by rosbuild.
+     * @param name The stackage to work on.
+     * @param direct If true, then compute only direct dependencies.  If
+     *               false, then compute full (including indirect) dependencies.
+     */
     bool depsManifests(const std::string& name, bool direct,
                        std::vector<std::string>& manifests);
     /**

--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -53,7 +53,7 @@ the colon-separated list of directories ROS_PACKAGE_PATH, in the order they
 are listed.
 
 During the crawl, librospack examines the contents of each directory, looking
-for a file called @b manifest.xml (for packages) or @b stack.xml (for stacks).
+for a file called @b package.xml / manifest.xml (for packages) or @b stack.xml (for stacks).
 If such a file is found, the directory
 containing it is considered to be a ROS stackage, with the stackage name
 equal to the directory name.  The crawl does not descend further once a

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -681,6 +681,20 @@ Rosstackage::depsManifests(const std::string& name, bool direct,
 }
 
 bool
+Rosstackage::depsDetail_pub(const std::string& name, bool direct,
+                            std::vector<Stackage*>& deps)
+{
+  return depsDetail(name, direct, deps);
+}
+
+bool
+Rosstackage::depsOnDetail_pub(const std::string& name, bool direct,
+                              std::vector<Stackage*>& deps, bool ignore_missing)
+{
+  return depsOnDetail(name, direct, deps, ignore_missing);
+}
+
+bool
 Rosstackage::rosdeps(const std::string& name, bool direct,
                      std::set<std::string>& rosdeps)
 {


### PR DESCRIPTION
Suggested code in #65, which changes existing functions signature, breaks ABI compatibility.
Instead, this PR adds new functions that internally call existing functions, to keep ABI unchanged.

As I added notes to the api doc, each new function, `depsDetail_pub` and `depsOnDetail_pub`, are only temporary and will not have to be added to the next distro branch (I suppose `lunar-devel` that is already created).