### PR TITLE
Fixed inverted result code check in new TinyXML-2 code

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -1554,7 +1554,7 @@ Rosstackage::loadManifest(Stackage* stackage)
   if(stackage->manifest_loaded_)
     return;
 
-  if(!stackage->manifest_.LoadFile(stackage->manifest_path_.c_str()))
+  if(stackage->manifest_.LoadFile(stackage->manifest_path_.c_str()) != XML_SUCCESS)
   {
     std::string errmsg = std::string("error parsing manifest of package ") +
             stackage->name_ + " at " + stackage->manifest_path_;


### PR DESCRIPTION
```
$ rospack profile       
terminate called after throwing an instance of 'rospack::Exception'
  what():  error parsing manifest of package rviz at /usr/share/ros_packages/rviz/package.xml
```

Actually XMLDocument::LoadFile returned XML_SUCCESS (== 0), but the current implementation throws an exception if LoadFile returns 0.