### PR TITLE
Fixed Python.h redefining pre-processor definitions

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <Python.h>
 #include "rospack/rospack.h"
 #include "utils.h"
 #include "tinyxml2.h"
@@ -68,8 +69,6 @@
 #include <time.h>
 #include <string.h>
 #include <errno.h>
-
-#include <Python.h>
 
 /* re-define some String functions for python 2.x */
 #if PY_VERSION_HEX < 0x03000000


### PR DESCRIPTION
https://docs.python.org/2/c-api/intro.html#include-files

"Since Python may define some pre-processor definitions which affect the
standard headers on some systems, you must include Python.h before any
standard headers are included."

g++7 warns about this:

In file included from /usr/include/python2.7/Python.h:8:0,
                 from /home/racko/ros_ws/src/rospack/src/rospack.cpp:29:
/usr/include/python2.7/pyconfig.h:1190:0: warning: "_POSIX_C_SOURCE"
redefined
In file included from /usr/include/python2.7/Python.h:8:0,
                 from /home/racko/ros_ws/src/rospack/src/rospack.cpp:29:
/usr/include/python2.7/pyconfig.h:1212:0: warning: "_XOPEN_SOURCE"
redefined