### PR TITLE
Suppress warning if permission to read directory is lacking

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -349,7 +349,10 @@ Rosstackage::isStackage(const std::string& path)
   }
   catch(fs::filesystem_error& e)
   {
-    logWarn(std::string("error while crawling ") + path + ": " + e.what());
+    // suppress logging of error message if reading of directory failed
+    // due to missing permission
+    if(e.code().value() != EACCES)
+      logWarn(std::string("error while crawling ") + path + ": " + e.what() + ";  " + e.code().message());
   }
   return false;
 }


### PR DESCRIPTION
Issue #58 addressed the wish to remove warnings printed by rospack
which are caused by the lack of read permission.

This small patch works but to me feels very hacky and non-intuitive to filter like this.

Maybe the filtering would be better located in the logWarn or even log function.
There we could introduce the check of a set containing all unwanted errors (if existent).
As the log functions are widely used and not just within catch blocks where the passing of the exception
would be possible, doing so might introduce quite a lot of changes.

So before I prepare an extensive PR for an issue that is mainly of cosmetic nature I would like to know the opinion of the maintainers if it is worth it.