### PR TITLE
add run_depend on ros_environment

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <run_depend>python</run_depend>
   <run_depend>python-catkin-pkg</run_depend>
   <run_depend>python-rosdep</run_depend>
+  <run_depend>ros_environment</run_depend>
   <run_depend>tinyxml2</run_depend>
 
   <test_depend>python-coverage</test_depend>


### PR DESCRIPTION
This package only works properly if the ROS environment variables have been set. (https://github.com/ros/ros/issues/156)