### PR TITLE
use namespace to avoid name conflict between tinyxml2 and msxml

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -80,7 +80,8 @@
 #define PyUnicode_FromString PyString_FromString
 #endif
 
-using namespace tinyxml2;
+// use namespace to disambiguate from MSXML on Windows
+namespace tx2 = tinyxml2;
 
 // TODO:
 //   recrawl on:
@@ -116,7 +117,7 @@ static const int MAX_CRAWL_DEPTH = 1000;
 static const int MAX_DEPENDENCY_DEPTH = 1000;
 static const double DEFAULT_MAX_CACHE_AGE = 60.0;
 
-XMLElement* get_manifest_root(Stackage* stackage);
+tx2::XMLElement* get_manifest_root(Stackage* stackage);
 double time_since_epoch();
 
 #ifdef __APPLE__
@@ -153,7 +154,7 @@ class Stackage
     // \brief have we already loaded the manifest?
     bool manifest_loaded_;
     // \brief TinyXML structure, filled in during parsing
-    XMLDocument manifest_;
+    tx2::XMLDocument manifest_;
     std::vector<Stackage*> deps_;
     bool deps_computed_;
     bool is_wet_package_;
@@ -179,20 +180,20 @@ class Stackage
       assert(is_wet_package_);
       assert(manifest_loaded_);
       // get name from package.xml instead of folder name
-      XMLElement* root = get_manifest_root(this);
-      for(XMLElement* el = root->FirstChildElement("name"); el; el = el->NextSiblingElement("name"))
+      tx2::XMLElement* root = get_manifest_root(this);
+      for(tx2::XMLElement* el = root->FirstChildElement("name"); el; el = el->NextSiblingElement("name"))
       {
         name_ = el->GetText();
         break;
       }
       // Get license texts, where there may be multiple elements for.
       std::string tagname_license = "license";
-      for(XMLElement* el = root->FirstChildElement(tagname_license.c_str()); el; el = el->NextSiblingElement(tagname_license.c_str()))
+      for(tx2::XMLElement* el = root->FirstChildElement(tagname_license.c_str()); el; el = el->NextSiblingElement(tagname_license.c_str()))
       {
         licenses_.push_back(el->GetText());
       }
       // check if package is a metapackage
-      for(XMLElement* el = root->FirstChildElement("export"); el; el = el->NextSiblingElement("export"))
+      for(tx2::XMLElement* el = root->FirstChildElement("export"); el; el = el->NextSiblingElement("export"))
       {
         if(el->FirstChildElement("metapackage"))
         {
@@ -736,8 +737,8 @@ Rosstackage::rosdeps(const std::string& name, bool direct,
 void
 Rosstackage::_rosdeps(Stackage* stackage, std::set<std::string>& rosdeps, const char* tag_name)
 {
-  XMLElement* root = get_manifest_root(stackage);
-  for(XMLElement* ele = root->FirstChildElement(tag_name);
+  tx2::XMLElement* root = get_manifest_root(stackage);
+  for(tx2::XMLElement* ele = root->FirstChildElement(tag_name);
       ele;
       ele = ele->NextSiblingElement(tag_name))
   {
@@ -779,8 +780,8 @@ Rosstackage::vcs(const std::string& name, bool direct,
         it != deps_vec.end();
         ++it)
     {
-      XMLElement* root = get_manifest_root(*it);
-      for(XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_VERSIONCONTROL);
+      tx2::XMLElement* root = get_manifest_root(*it);
+      for(tx2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_VERSIONCONTROL);
           ele;
           ele = ele->NextSiblingElement(MANIFEST_TAG_VERSIONCONTROL))
       {
@@ -1021,14 +1022,14 @@ Rosstackage::exports_dry_package(Stackage* stackage, const std::string& lang,
                      const std::string& attrib,
                      std::vector<std::string>& flags)
 {
-  XMLElement* root = get_manifest_root(stackage);
-  for(XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
+  tx2::XMLElement* root = get_manifest_root(stackage);
+  for(tx2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
       ele;
       ele = ele->NextSiblingElement(MANIFEST_TAG_EXPORT))
   {
     bool os_match = false;
     const char *best_match = NULL;
-    for(XMLElement* ele2 = ele->FirstChildElement(lang.c_str());
+    for(tx2::XMLElement* ele2 = ele->FirstChildElement(lang.c_str());
         ele2;
         ele2 = ele2->NextSiblingElement(lang.c_str()))
     {
@@ -1127,12 +1128,12 @@ Rosstackage::plugins(const std::string& name, const std::string& attrib,
       it != stackages.end();
       ++it)
   {
-    XMLElement* root = get_manifest_root(*it);
-    for(XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
+    tx2::XMLElement* root = get_manifest_root(*it);
+    for(tx2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
         ele;
         ele = ele->NextSiblingElement(MANIFEST_TAG_EXPORT))
     {
-      for(XMLElement* ele2 = ele->FirstChildElement(name.c_str());
+      for(tx2::XMLElement* ele2 = ele->FirstChildElement(name.c_str());
           ele2;
           ele2 = ele2->NextSiblingElement(name.c_str()))
       {
@@ -1563,7 +1564,7 @@ Rosstackage::loadManifest(Stackage* stackage)
   if(stackage->manifest_loaded_)
     return;
 
-  if(stackage->manifest_.LoadFile(stackage->manifest_path_.c_str()) != XML_SUCCESS)
+  if(stackage->manifest_.LoadFile(stackage->manifest_path_.c_str()) != tx2::XML_SUCCESS)
   {
     std::string errmsg = std::string("error parsing manifest of package ") +
             stackage->name_ + " at " + stackage->manifest_path_;
@@ -1609,11 +1610,11 @@ Rosstackage::computeDeps(Stackage* stackage, bool ignore_errors, bool ignore_mis
 void
 Rosstackage::computeDepsInternal(Stackage* stackage, bool ignore_errors, const std::string& depend_tag, bool ignore_missing)
 {
-  XMLElement* root;
+  tx2::XMLElement* root;
   root = get_manifest_root(stackage);
 
   const char* dep_pkgname;
-  for(XMLElement *dep_ele = root->FirstChildElement(depend_tag.c_str());
+  for(tx2::XMLElement *dep_ele = root->FirstChildElement(depend_tag.c_str());
       dep_ele;
       dep_ele = dep_ele->NextSiblingElement(depend_tag.c_str()))
   {
@@ -2338,10 +2339,10 @@ std::string Rosstack::get_manifest_type()
   return "stack";
 }
 
-XMLElement*
+tx2::XMLElement*
 get_manifest_root(Stackage* stackage)
 {
-  XMLElement* ele = stackage->manifest_.RootElement();
+  tx2::XMLElement* ele = stackage->manifest_.RootElement();
   if(!ele)
   {
     std::string errmsg = std::string("error parsing manifest of package ") +

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -80,9 +80,6 @@
 #define PyUnicode_FromString PyString_FromString
 #endif
 
-// use namespace to disambiguate from MSXML on Windows
-namespace tx2 = tinyxml2;
-
 // TODO:
 //   recrawl on:
 //     package not found in cache
@@ -117,7 +114,7 @@ static const int MAX_CRAWL_DEPTH = 1000;
 static const int MAX_DEPENDENCY_DEPTH = 1000;
 static const double DEFAULT_MAX_CACHE_AGE = 60.0;
 
-tx2::XMLElement* get_manifest_root(Stackage* stackage);
+tinyxml2::XMLElement* get_manifest_root(Stackage* stackage);
 double time_since_epoch();
 
 #ifdef __APPLE__
@@ -154,7 +151,7 @@ class Stackage
     // \brief have we already loaded the manifest?
     bool manifest_loaded_;
     // \brief TinyXML structure, filled in during parsing
-    tx2::XMLDocument manifest_;
+    tinyxml2::XMLDocument manifest_;
     std::vector<Stackage*> deps_;
     bool deps_computed_;
     bool is_wet_package_;
@@ -180,20 +177,20 @@ class Stackage
       assert(is_wet_package_);
       assert(manifest_loaded_);
       // get name from package.xml instead of folder name
-      tx2::XMLElement* root = get_manifest_root(this);
-      for(tx2::XMLElement* el = root->FirstChildElement("name"); el; el = el->NextSiblingElement("name"))
+      tinyxml2::XMLElement* root = get_manifest_root(this);
+      for(tinyxml2::XMLElement* el = root->FirstChildElement("name"); el; el = el->NextSiblingElement("name"))
       {
         name_ = el->GetText();
         break;
       }
       // Get license texts, where there may be multiple elements for.
       std::string tagname_license = "license";
-      for(tx2::XMLElement* el = root->FirstChildElement(tagname_license.c_str()); el; el = el->NextSiblingElement(tagname_license.c_str()))
+      for(tinyxml2::XMLElement* el = root->FirstChildElement(tagname_license.c_str()); el; el = el->NextSiblingElement(tagname_license.c_str()))
       {
         licenses_.push_back(el->GetText());
       }
       // check if package is a metapackage
-      for(tx2::XMLElement* el = root->FirstChildElement("export"); el; el = el->NextSiblingElement("export"))
+      for(tinyxml2::XMLElement* el = root->FirstChildElement("export"); el; el = el->NextSiblingElement("export"))
       {
         if(el->FirstChildElement("metapackage"))
         {
@@ -737,8 +734,8 @@ Rosstackage::rosdeps(const std::string& name, bool direct,
 void
 Rosstackage::_rosdeps(Stackage* stackage, std::set<std::string>& rosdeps, const char* tag_name)
 {
-  tx2::XMLElement* root = get_manifest_root(stackage);
-  for(tx2::XMLElement* ele = root->FirstChildElement(tag_name);
+  tinyxml2::XMLElement* root = get_manifest_root(stackage);
+  for(tinyxml2::XMLElement* ele = root->FirstChildElement(tag_name);
       ele;
       ele = ele->NextSiblingElement(tag_name))
   {
@@ -780,8 +777,8 @@ Rosstackage::vcs(const std::string& name, bool direct,
         it != deps_vec.end();
         ++it)
     {
-      tx2::XMLElement* root = get_manifest_root(*it);
-      for(tx2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_VERSIONCONTROL);
+      tinyxml2::XMLElement* root = get_manifest_root(*it);
+      for(tinyxml2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_VERSIONCONTROL);
           ele;
           ele = ele->NextSiblingElement(MANIFEST_TAG_VERSIONCONTROL))
       {
@@ -1022,14 +1019,14 @@ Rosstackage::exports_dry_package(Stackage* stackage, const std::string& lang,
                      const std::string& attrib,
                      std::vector<std::string>& flags)
 {
-  tx2::XMLElement* root = get_manifest_root(stackage);
-  for(tx2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
+  tinyxml2::XMLElement* root = get_manifest_root(stackage);
+  for(tinyxml2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
       ele;
       ele = ele->NextSiblingElement(MANIFEST_TAG_EXPORT))
   {
     bool os_match = false;
     const char *best_match = NULL;
-    for(tx2::XMLElement* ele2 = ele->FirstChildElement(lang.c_str());
+    for(tinyxml2::XMLElement* ele2 = ele->FirstChildElement(lang.c_str());
         ele2;
         ele2 = ele2->NextSiblingElement(lang.c_str()))
     {
@@ -1128,12 +1125,12 @@ Rosstackage::plugins(const std::string& name, const std::string& attrib,
       it != stackages.end();
       ++it)
   {
-    tx2::XMLElement* root = get_manifest_root(*it);
-    for(tx2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
+    tinyxml2::XMLElement* root = get_manifest_root(*it);
+    for(tinyxml2::XMLElement* ele = root->FirstChildElement(MANIFEST_TAG_EXPORT);
         ele;
         ele = ele->NextSiblingElement(MANIFEST_TAG_EXPORT))
     {
-      for(tx2::XMLElement* ele2 = ele->FirstChildElement(name.c_str());
+      for(tinyxml2::XMLElement* ele2 = ele->FirstChildElement(name.c_str());
           ele2;
           ele2 = ele2->NextSiblingElement(name.c_str()))
       {
@@ -1564,7 +1561,7 @@ Rosstackage::loadManifest(Stackage* stackage)
   if(stackage->manifest_loaded_)
     return;
 
-  if(stackage->manifest_.LoadFile(stackage->manifest_path_.c_str()) != tx2::XML_SUCCESS)
+  if(stackage->manifest_.LoadFile(stackage->manifest_path_.c_str()) != tinyxml2::XML_SUCCESS)
   {
     std::string errmsg = std::string("error parsing manifest of package ") +
             stackage->name_ + " at " + stackage->manifest_path_;
@@ -1610,11 +1607,11 @@ Rosstackage::computeDeps(Stackage* stackage, bool ignore_errors, bool ignore_mis
 void
 Rosstackage::computeDepsInternal(Stackage* stackage, bool ignore_errors, const std::string& depend_tag, bool ignore_missing)
 {
-  tx2::XMLElement* root;
+  tinyxml2::XMLElement* root;
   root = get_manifest_root(stackage);
 
   const char* dep_pkgname;
-  for(tx2::XMLElement *dep_ele = root->FirstChildElement(depend_tag.c_str());
+  for(tinyxml2::XMLElement *dep_ele = root->FirstChildElement(depend_tag.c_str());
       dep_ele;
       dep_ele = dep_ele->NextSiblingElement(depend_tag.c_str()))
   {
@@ -2339,10 +2336,10 @@ std::string Rosstack::get_manifest_type()
   return "stack";
 }
 
-tx2::XMLElement*
+tinyxml2::XMLElement*
 get_manifest_root(Stackage* stackage)
 {
-  tx2::XMLElement* ele = stackage->manifest_.RootElement();
+  tinyxml2::XMLElement* ele = stackage->manifest_.RootElement();
   if(!ele)
   {
     std::string errmsg = std::string("error parsing manifest of package ") +


### PR DESCRIPTION
use namespace to avoid name conflict between tinyxml2 and msxml