### PR TITLE
enable to run rosstack depends for wetpackages

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -1411,8 +1411,11 @@ Rosstackage::addStackage(const std::string& path)
   }
 
   // skip the stackage if it is not of correct type
-  if((manifest_name_ == ROSSTACK_MANIFEST_NAME && stackage->isPackage()) ||
-     (manifest_name_ == ROSPACK_MANIFEST_NAME && stackage->isStack()))
+  if( (stackage->is_wet_package_ &&
+       (manifest_name_ == ROSPACKAGE_MANIFEST_NAME)) ||
+      (!stackage->is_wet_package_ &&
+       (manifest_name_ == ROSSTACK_MANIFEST_NAME && stackage->isPackage()) ||
+       (manifest_name_ == ROSPACK_MANIFEST_NAME && stackage->isStack())) )
   {
     delete stackage;
     return;


### PR DESCRIPTION
with out this PR, 
```
        $ rospack depends image_common
        [rospack] Error: no such package image_common
```
this is ok, but 
```
        $ rosstack depends image_common
        [rosstack] Error: stack 'image_common' depends on non-existent package 'camera_calibration_parsers' and rosdep claims that it is not a system dependency. Check the ROS_PACKAGE_PATH or try calling 'rosdep update'
```
is not an expected behavior. Although this is `rosstack` command, but should be work with `catkin` `metapackage`.