### PR TITLE
Add delete whitespace settings for backward compatibility

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -163,6 +163,7 @@ class Stackage
              const std::string& manifest_name) :
             name_(name),
             path_(path),
+            manifest_(true, tinyxml2::COLLAPSE_WHITESPACE),
             manifest_path_(manifest_path),
             manifest_name_(manifest_name),
             manifest_loaded_(false),

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -163,10 +163,10 @@ class Stackage
              const std::string& manifest_name) :
             name_(name),
             path_(path),
-            manifest_(true, tinyxml2::COLLAPSE_WHITESPACE),
             manifest_path_(manifest_path),
             manifest_name_(manifest_name),
             manifest_loaded_(false),
+            manifest_(true, tinyxml2::COLLAPSE_WHITESPACE),
             deps_computed_(false),
             is_metapackage_(false)
     {


### PR DESCRIPTION
From this commit (https://github.com/ros/rospack/commit/cc463fa683ca4cfd79cfe71b73e1ca2ef13e4ae3), 
Whitespace is no longer erased. 

For instance,  
```
<package>
  <name>
    jsk_interactive_marker
  </name>
  <description>
    jsk interactive markers
  </description>
</package>
```

Previous result of ```rospack plugins``` is following

```
root@f9a401aa8506:/ros_ws/src/rospack# rospack plugins --attrib=plugin rviz
jsk_rviz_plugins /ros_ws/src/jsk_visualization/jsk_rviz_plugins/plugin_description.xml
jsk_interactive_marker /ros_ws/src/jsk_visualization/jsk_interactive_markers/jsk_interactive_marker/plugin_description.xml
rviz /opt/ros/lunar/share/rviz/plugin_description.xml
```

But, the result of current master is folllowing

```
root@f9a401aa8506:/ros_ws/src/rospack# rospack plugins --attrib=plugin rviz
jsk_rviz_plugins /ros_ws/src/jsk_visualization/jsk_rviz_plugins/plugin_description.xml

    jsk_interactive_marker
   /ros_ws/src/jsk_visualization/jsk_interactive_markers/jsk_interactive_marker/plugin_description.xml
rviz /opt/ros/lunar/share/rviz/plugin_description.xml
```
This PR makes this behavior the same as before.

