### PR TITLE
Add ros_environment as dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <run_depend>python</run_depend>
   <run_depend>python-catkin-pkg</run_depend>
   <run_depend>python-rosdep</run_depend>
+  <run_depend>ros_environment</run_depend>
   <run_depend>tinyxml</run_depend>
 
   <test_depend>python-coverage</test_depend>


### PR DESCRIPTION
Add ros_environment as run_dependency as on branch lunar-devel, as it is needed for `rospack list-names` to work. See also https://github.com/ros/rospack/commit/70eac5dec07311f9cacccddb301a8bc9b4efb671