### PR TITLE
fixing mkstemp without securely setting mask/unmask

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -2061,7 +2061,7 @@ Rosstackage::writeCache()
     {
       FILE *cache = fopen(tmp_cache_path, "w");
 #else
-    mode_t mask = umask(S_IRUSR | S_IWUSR| S_IXUSR | S_IRWXG);
+    mode_t mask = umask(S_IRWXU);
     int fd = mkstemp(tmp_cache_path);
     umask(mask);
     if (fd < 0)

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -2061,7 +2061,9 @@ Rosstackage::writeCache()
     {
       FILE *cache = fopen(tmp_cache_path, "w");
 #else
+    mode_t mask = umask(S_IRUSR | S_IWUSR| S_IXUSR | S_IRWXG);
     int fd = mkstemp(tmp_cache_path);
+    umask(mask);
     if (fd < 0)
     {
       fprintf(stderr, "[rospack] Unable to create temporary cache file %s: %s\n",


### PR DESCRIPTION
fix https://github.com/ros/rospack/issues/101

In newer glibc's (versions > 2.06) reasonably secure permissions of 0600 are used when creating a temporary file with mkstemp(). But for older glibc and other platform this is not guaranteed.

Signed-off-by: Daniel Wang <daniel.wang@canonical.com>