### PR TITLE
[Windows][melodic-devel] rework validateCache for portability.

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -2112,15 +2112,6 @@ Rosstackage::validateCache()
     cache_max_age = atof(user_cache_time_str);
   if(cache_max_age == 0.0)
     return NULL;
-  struct stat ls;
-  if(lstat(cache_path.c_str(), &ls) == -1)
-    return NULL;
-
-  double dt = difftime(time(NULL), ls.st_mtime);
-  // Negative cache_max_age means it's always new enough.  It's dangerous
-  // for the user to set this, but rosbash uses it.
-  if ((cache_max_age > 0.0) && (dt > cache_max_age))
-    return NULL;
 
   // try to open it
   FILE* cache = fopen(cache_path.c_str(), "r");
@@ -2133,10 +2124,14 @@ Rosstackage::validateCache()
     fclose(cache);
     return NULL;
   }
-  if (ls.st_mode != s.st_mode || ls.st_ino != s.st_ino)
+
+  double dt = difftime(time(NULL), s.st_mtime);
+  // Negative cache_max_age means it's always new enough.  It's dangerous
+  // for the user to set this, but rosbash uses it.
+  if ((cache_max_age > 0.0) && (dt > cache_max_age))
   {
     fclose(cache);
-    throw Exception("cache stat mode does not match before open");
+    return NULL;
   }
 
   // see if ROS_PACKAGE_PATH matches


### PR DESCRIPTION
In a recent change of [`for fixing potential TOCTOU issue`](https://github.com/ros/rospack/pull/104), it introduced the usage of `lstat` but unfortunately not every platform (e.g., `Windows`) supports this `posix` function.

In order to make `rospack` still portable on Windows, this pull request is attempting to rearrange the `validateCache` implementation to drop the `lstat` usage, but still keeps it from `TOCTOU` issue.