### PR TITLE
fix boost tr1 deprecation (kinetic)

### DIFF
--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -105,8 +105,16 @@ and Rosstack.
 #ifndef ROSPACK_ROSPACK_H
 #define ROSPACK_ROSPACK_H
 
+#include <boost/version.hpp>
+
+#if BOOST_VERSION <= 106500
 #include <boost/tr1/unordered_set.hpp>
 #include <boost/tr1/unordered_map.hpp>
+#else
+#include <boost/unordered_set.hpp>
+#include <boost/unordered_map.hpp>
+#endif
+
 #include <list>
 #include <map>
 #include <set>
@@ -194,18 +202,32 @@ class ROSPACK_DECL Rosstackage
     std::string tag_;
     bool quiet_;
     std::vector<std::string> search_paths_;
+#if BOOST_VERSION <= 106500
     std::tr1::unordered_map<std::string, std::vector<std::string> > dups_;
     std::tr1::unordered_map<std::string, Stackage*> stackages_;
+#else
+    boost::unordered_map<std::string, std::vector<std::string> > dups_;
+    boost::unordered_map<std::string, Stackage*> stackages_;
+#endif
     Stackage* findWithRecrawl(const std::string& name);
     void log(const std::string& level, const std::string& msg, bool append_errno);
     void clearStackages();
     void addStackage(const std::string& path);
+#if BOOST_VERSION <= 106500
     void crawlDetail(const std::string& path,
                      bool force,
                      int depth,
                      bool collect_profile_data,
                      std::vector<DirectoryCrawlRecord*>& profile_data,
                      std::tr1::unordered_set<std::string>& profile_hash);
+#else
+    void crawlDetail(const std::string& path,
+                     bool force,
+                     int depth,
+                     bool collect_profile_data,
+                     std::vector<DirectoryCrawlRecord*>& profile_data,
+                     boost::unordered_set<std::string>& profile_hash);
+#endif
     bool isStackage(const std::string& path);
     void loadManifest(Stackage* stackage);
     void computeDeps(Stackage* stackage, bool ignore_errors=false, bool ignore_missing=false);
@@ -215,6 +237,7 @@ class ROSPACK_DECL Rosstackage
                     traversal_order_t order,
                     std::vector<Stackage*>& deps,
                     bool no_recursion_on_wet=false);
+#if BOOST_VERSION <= 106500
     void gatherDepsFull(Stackage* stackage, bool direct,
                         traversal_order_t order, int depth,
                         std::tr1::unordered_set<Stackage*>& deps_hash,
@@ -222,6 +245,15 @@ class ROSPACK_DECL Rosstackage
                         bool get_indented_deps,
                         std::vector<std::string>& indented_deps,
                         bool no_recursion_on_wet=false);
+#else
+    void gatherDepsFull(Stackage* stackage, bool direct,
+                        traversal_order_t order, int depth,
+                        boost::unordered_set<Stackage*>& deps_hash,
+                        std::vector<Stackage*>& deps,
+                        bool get_indented_deps,
+                        std::vector<std::string>& indented_deps,
+                        bool no_recursion_on_wet=false);
+#endif
     std::string getCachePath();
     std::string getCacheHash();
     bool readCache();

--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -107,7 +107,7 @@ and Rosstack.
 
 #include <boost/version.hpp>
 
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
 #include <boost/tr1/unordered_set.hpp>
 #include <boost/tr1/unordered_map.hpp>
 #else
@@ -202,7 +202,7 @@ class ROSPACK_DECL Rosstackage
     std::string tag_;
     bool quiet_;
     std::vector<std::string> search_paths_;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
     std::tr1::unordered_map<std::string, std::vector<std::string> > dups_;
     std::tr1::unordered_map<std::string, Stackage*> stackages_;
 #else
@@ -213,19 +213,14 @@ class ROSPACK_DECL Rosstackage
     void log(const std::string& level, const std::string& msg, bool append_errno);
     void clearStackages();
     void addStackage(const std::string& path);
-#if BOOST_VERSION <= 106500
     void crawlDetail(const std::string& path,
                      bool force,
                      int depth,
                      bool collect_profile_data,
                      std::vector<DirectoryCrawlRecord*>& profile_data,
+#if BOOST_VERSION < 106500
                      std::tr1::unordered_set<std::string>& profile_hash);
 #else
-    void crawlDetail(const std::string& path,
-                     bool force,
-                     int depth,
-                     bool collect_profile_data,
-                     std::vector<DirectoryCrawlRecord*>& profile_data,
                      boost::unordered_set<std::string>& profile_hash);
 #endif
     bool isStackage(const std::string& path);
@@ -237,23 +232,17 @@ class ROSPACK_DECL Rosstackage
                     traversal_order_t order,
                     std::vector<Stackage*>& deps,
                     bool no_recursion_on_wet=false);
-#if BOOST_VERSION <= 106500
     void gatherDepsFull(Stackage* stackage, bool direct,
                         traversal_order_t order, int depth,
+#if BOOST_VERSION < 106500
                         std::tr1::unordered_set<Stackage*>& deps_hash,
-                        std::vector<Stackage*>& deps,
-                        bool get_indented_deps,
-                        std::vector<std::string>& indented_deps,
-                        bool no_recursion_on_wet=false);
 #else
-    void gatherDepsFull(Stackage* stackage, bool direct,
-                        traversal_order_t order, int depth,
                         boost::unordered_set<Stackage*>& deps_hash,
+#endif
                         std::vector<Stackage*>& deps,
                         bool get_indented_deps,
                         std::vector<std::string>& indented_deps,
                         bool no_recursion_on_wet=false);
-#endif
     std::string getCachePath();
     std::string getCacheHash();
     bool readCache();

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -258,9 +258,15 @@ Rosstackage::~Rosstackage()
 
 void Rosstackage::clearStackages()
 {
+#if BOOST_VERSION <= 106500
   for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
       it != stackages_.end();
       ++it)
+#else
+  for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+      it != stackages_.end();
+      ++it)
+#endif
   {
     delete it->second;
   }
@@ -381,7 +387,12 @@ Rosstackage::crawl(std::vector<std::string> search_path,
   search_paths_ = search_path;
 
   std::vector<DirectoryCrawlRecord*> dummy;
+  
+#if BOOST_VERSION <= 106500
   std::tr1::unordered_set<std::string> dummy2;
+#else
+  boost::unordered_set<std::string> dummy2;
+#endif
   for(std::vector<std::string>::const_iterator p = search_paths_.begin();
       p != search_paths_.end();
       ++p)
@@ -446,7 +457,11 @@ Rosstackage::contents(const std::string& name,
                       std::set<std::string>& packages)
 {
   Rospack rp2;
+#if BOOST_VERSION <= 106500
   std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
+#else
+  boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
+#endif
   if(it != stackages_.end())
   {
     std::vector<std::string> search_paths;
@@ -473,9 +488,15 @@ Rosstackage::contains(const std::string& name,
                       std::string& path)
 {
   Rospack rp2;
+#if BOOST_VERSION <= 106500
   for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
       it != stackages_.end();
       ++it)
+#else
+for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+      it != stackages_.end();
+      ++it)
+#endif
   {
     std::vector<std::string> search_paths;
     search_paths.push_back(it->second->path_);
@@ -502,9 +523,16 @@ Rosstackage::contains(const std::string& name,
 void
 Rosstackage::list(std::set<std::pair<std::string, std::string> >& list)
 {
+#if BOOST_VERSION <= 106500
   for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
       it != stackages_.end();
       ++it)
+#else
+  for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+      it != stackages_.end();
+      ++it)
+#endif
+
   {
     std::pair<std::string, std::string> item;
     item.first = it->first;
@@ -518,9 +546,15 @@ Rosstackage::listDuplicates(std::vector<std::string>& dups)
 {
   dups.resize(dups_.size());
   int i = 0;
+#if BOOST_VERSION <= 106500
   for(std::tr1::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
       it != dups_.end();
       ++it)
+#else
+for(boost::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
+      it != dups_.end();
+      ++it)
+#endif
   {
     dups[i] = it->first;
     i++;
@@ -531,9 +565,15 @@ void
 Rosstackage::listDuplicatesWithPaths(std::map<std::string, std::vector<std::string> >& dups)
 {
   dups.clear();
+#if BOOST_VERSION <= 106500
   for(std::tr1::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
       it != dups_.end();
       ++it)
+#else
+  for(boost::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
+      it != dups_.end();
+      ++it)
+#endif
   {
     dups[it->first].resize(it->second.size());
     int j = 0;
@@ -597,7 +637,11 @@ Rosstackage::depsIndent(const std::string& name, bool direct,
   {
     computeDeps(stackage);
     std::vector<Stackage*> deps_vec;
+#if BOOST_VERSION <= 106500
     std::tr1::unordered_set<Stackage*> deps_hash;
+#else
+    boost::unordered_set<Stackage*> deps_hash;
+#endif
     std::vector<std::string> indented_deps;
     gatherDepsFull(stackage, direct, POSTORDER, 0, deps_hash, deps_vec, true, indented_deps);
     for(std::vector<std::string>::const_iterator it = indented_deps.begin();
@@ -1088,7 +1132,11 @@ Rosstackage::plugins(const std::string& name, const std::string& attrib,
   if(!depsOnDetail(name, true, stackages, true))
     return false;
   // Also look in the package itself
+#if BOOST_VERSION <= 106500
   std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
+#else
+  boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
+ #endif 
   if(it != stackages_.end())
   {
     // don't warn here; it was done in depsOnDetail()
@@ -1101,7 +1149,11 @@ Rosstackage::plugins(const std::string& name, const std::string& attrib,
     std::vector<Stackage*> top_deps;
     if(!depsDetail(top, false, top_deps))
       return false;
+#if BOOST_VERSION <= 106500
     std::tr1::unordered_set<Stackage*> top_deps_set;
+#else
+    boost::unordered_set<Stackage*> top_deps_set;
+#endif
     for(std::vector<Stackage*>::iterator it = top_deps.begin();
         it != top_deps.end();
         ++it)
@@ -1291,9 +1343,15 @@ Rosstackage::depsOnDetail(const std::string& name, bool direct,
   }
   try
   {
+#if BOOST_VERSION <= 106500
     for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
         it != stackages_.end();
         ++it)
+#else
+    for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+        it != stackages_.end();
+        ++it)
+#endif
     {
       computeDeps(it->second, true, ignore_missing);
       std::vector<Stackage*> deps_vec;
@@ -1326,7 +1384,11 @@ Rosstackage::profile(const std::vector<std::string>& search_path,
 {
   double start = time_since_epoch();
   std::vector<DirectoryCrawlRecord*> dcrs;
+#if BOOST_VERSION <= 106500
   std::tr1::unordered_set<std::string> dcrs_hash;
+#else
+  boost::unordered_set<std::string> dcrs_hash;
+#endif
   for(std::vector<std::string>::const_iterator p = search_path.begin();
       p != search_path.end();
       ++p)
@@ -1430,6 +1492,7 @@ Rosstackage::addStackage(const std::string& path)
   stackages_[stackage->name_] = stackage;
 }
 
+#if BOOST_VERSION <= 106500
 void
 Rosstackage::crawlDetail(const std::string& path,
                          bool force,
@@ -1437,6 +1500,15 @@ Rosstackage::crawlDetail(const std::string& path,
                          bool collect_profile_data,
                          std::vector<DirectoryCrawlRecord*>& profile_data,
                          std::tr1::unordered_set<std::string>& profile_hash)
+#else
+void
+Rosstackage::crawlDetail(const std::string& path,
+                         bool force,
+                         int depth,
+                         bool collect_profile_data,
+                         std::vector<DirectoryCrawlRecord*>& profile_data,
+                         boost::unordered_set<std::string>& profile_hash)
+#endif
 {
   if(depth > MAX_CRAWL_DEPTH)
     throw Exception("maximum depth exceeded during crawl");
@@ -1785,12 +1857,17 @@ Rosstackage::gatherDeps(Stackage* stackage, bool direct,
                         std::vector<Stackage*>& deps,
                         bool no_recursion_on_wet)
 {
+#if BOOST_VERSION <= 106500
   std::tr1::unordered_set<Stackage*> deps_hash;
+#else
+  boost::unordered_set<Stackage*> deps_hash;
+#endif
   std::vector<std::string> indented_deps;
   gatherDepsFull(stackage, direct, order, 0,
                  deps_hash, deps, false, indented_deps, no_recursion_on_wet);
 }
 
+#if BOOST_VERSION <= 106500
 void
 _gatherDepsFull(Stackage* stackage, bool direct,
                             traversal_order_t order, int depth,
@@ -1800,6 +1877,17 @@ _gatherDepsFull(Stackage* stackage, bool direct,
                             std::vector<std::string>& indented_deps,
                             bool no_recursion_on_wet,
                             std::vector<std::string>& dep_chain)
+#else
+void
+_gatherDepsFull(Stackage* stackage, bool direct,
+                            traversal_order_t order, int depth,
+                            boost::unordered_set<Stackage*>& deps_hash,
+                            std::vector<Stackage*>& deps,
+                            bool get_indented_deps,
+                            std::vector<std::string>& indented_deps,
+                            bool no_recursion_on_wet,
+                            std::vector<std::string>& dep_chain)
+#endif
 {
   if(stackage->is_wet_package_ && no_recursion_on_wet)
   {
@@ -1877,6 +1965,7 @@ _gatherDepsFull(Stackage* stackage, bool direct,
 }
 
 // Pre-condition: computeDeps(stackage) succeeded
+#if BOOST_VERSION <= 106500
 void
 Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
                             traversal_order_t order, int depth,
@@ -1885,6 +1974,16 @@ Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
                             bool get_indented_deps,
                             std::vector<std::string>& indented_deps,
                             bool no_recursion_on_wet)
+#else
+void
+Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
+                            traversal_order_t order, int depth,
+                            boost::unordered_set<Stackage*>& deps_hash,
+                            std::vector<Stackage*>& deps,
+                            bool get_indented_deps,
+                            std::vector<std::string>& indented_deps,
+                            bool no_recursion_on_wet)
+#endif
 {
   std::vector<std::string> dep_chain;
   dep_chain.push_back(stackage->name_);
@@ -2067,9 +2166,15 @@ Rosstackage::writeCache()
       {
         char *rpp = getenv("ROS_PACKAGE_PATH");
         fprintf(cache, "#ROS_PACKAGE_PATH=%s\n", (rpp ? rpp : ""));
+#if BOOST_VERSION <= 106500
         for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
             it != stackages_.end();
             ++it)
+#else
+        for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+            it != stackages_.end();
+            ++it)
+#endif
           fprintf(cache, "%s\n", it->second->path_.c_str());
         fclose(cache);
         if(fs::exists(cache_path))

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -258,15 +258,13 @@ Rosstackage::~Rosstackage()
 
 void Rosstackage::clearStackages()
 {
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
-      it != stackages_.end();
-      ++it)
 #else
   for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+#endif
       it != stackages_.end();
       ++it)
-#endif
   {
     delete it->second;
   }
@@ -388,7 +386,7 @@ Rosstackage::crawl(std::vector<std::string> search_path,
 
   std::vector<DirectoryCrawlRecord*> dummy;
   
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   std::tr1::unordered_set<std::string> dummy2;
 #else
   boost::unordered_set<std::string> dummy2;
@@ -457,7 +455,7 @@ Rosstackage::contents(const std::string& name,
                       std::set<std::string>& packages)
 {
   Rospack rp2;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
 #else
   boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
@@ -488,15 +486,13 @@ Rosstackage::contains(const std::string& name,
                       std::string& path)
 {
   Rospack rp2;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
-      it != stackages_.end();
-      ++it)
 #else
-for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+  for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+#endif
       it != stackages_.end();
       ++it)
-#endif
   {
     std::vector<std::string> search_paths;
     search_paths.push_back(it->second->path_);
@@ -523,16 +519,13 @@ for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_
 void
 Rosstackage::list(std::set<std::pair<std::string, std::string> >& list)
 {
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
-      it != stackages_.end();
-      ++it)
 #else
   for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+#endif
       it != stackages_.end();
       ++it)
-#endif
-
   {
     std::pair<std::string, std::string> item;
     item.first = it->first;
@@ -546,15 +539,13 @@ Rosstackage::listDuplicates(std::vector<std::string>& dups)
 {
   dups.resize(dups_.size());
   int i = 0;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   for(std::tr1::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
-      it != dups_.end();
-      ++it)
 #else
-for(boost::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
+  for(boost::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
+#endif
       it != dups_.end();
       ++it)
-#endif
   {
     dups[i] = it->first;
     i++;
@@ -565,15 +556,13 @@ void
 Rosstackage::listDuplicatesWithPaths(std::map<std::string, std::vector<std::string> >& dups)
 {
   dups.clear();
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   for(std::tr1::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
-      it != dups_.end();
-      ++it)
 #else
   for(boost::unordered_map<std::string, std::vector<std::string> >::const_iterator it = dups_.begin();
+#endif
       it != dups_.end();
       ++it)
-#endif
   {
     dups[it->first].resize(it->second.size());
     int j = 0;
@@ -637,7 +626,7 @@ Rosstackage::depsIndent(const std::string& name, bool direct,
   {
     computeDeps(stackage);
     std::vector<Stackage*> deps_vec;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
     std::tr1::unordered_set<Stackage*> deps_hash;
 #else
     boost::unordered_set<Stackage*> deps_hash;
@@ -1132,7 +1121,7 @@ Rosstackage::plugins(const std::string& name, const std::string& attrib,
   if(!depsOnDetail(name, true, stackages, true))
     return false;
   // Also look in the package itself
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
 #else
   boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.find(name);
@@ -1149,7 +1138,7 @@ Rosstackage::plugins(const std::string& name, const std::string& attrib,
     std::vector<Stackage*> top_deps;
     if(!depsDetail(top, false, top_deps))
       return false;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
     std::tr1::unordered_set<Stackage*> top_deps_set;
 #else
     boost::unordered_set<Stackage*> top_deps_set;
@@ -1343,15 +1332,13 @@ Rosstackage::depsOnDetail(const std::string& name, bool direct,
   }
   try
   {
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
     for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
-        it != stackages_.end();
-        ++it)
 #else
     for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+#endif
         it != stackages_.end();
         ++it)
-#endif
     {
       computeDeps(it->second, true, ignore_missing);
       std::vector<Stackage*> deps_vec;
@@ -1384,7 +1371,7 @@ Rosstackage::profile(const std::vector<std::string>& search_path,
 {
   double start = time_since_epoch();
   std::vector<DirectoryCrawlRecord*> dcrs;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   std::tr1::unordered_set<std::string> dcrs_hash;
 #else
   boost::unordered_set<std::string> dcrs_hash;
@@ -1492,23 +1479,17 @@ Rosstackage::addStackage(const std::string& path)
   stackages_[stackage->name_] = stackage;
 }
 
-#if BOOST_VERSION <= 106500
 void
 Rosstackage::crawlDetail(const std::string& path,
                          bool force,
                          int depth,
                          bool collect_profile_data,
                          std::vector<DirectoryCrawlRecord*>& profile_data,
+#if BOOST_VERSION < 106500
                          std::tr1::unordered_set<std::string>& profile_hash)
 #else
-void
-Rosstackage::crawlDetail(const std::string& path,
-                         bool force,
-                         int depth,
-                         bool collect_profile_data,
-                         std::vector<DirectoryCrawlRecord*>& profile_data,
                          boost::unordered_set<std::string>& profile_hash)
-#endif
+#endif                         
 {
   if(depth > MAX_CRAWL_DEPTH)
     throw Exception("maximum depth exceeded during crawl");
@@ -1857,7 +1838,7 @@ Rosstackage::gatherDeps(Stackage* stackage, bool direct,
                         std::vector<Stackage*>& deps,
                         bool no_recursion_on_wet)
 {
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   std::tr1::unordered_set<Stackage*> deps_hash;
 #else
   boost::unordered_set<Stackage*> deps_hash;
@@ -1867,27 +1848,19 @@ Rosstackage::gatherDeps(Stackage* stackage, bool direct,
                  deps_hash, deps, false, indented_deps, no_recursion_on_wet);
 }
 
-#if BOOST_VERSION <= 106500
 void
 _gatherDepsFull(Stackage* stackage, bool direct,
                             traversal_order_t order, int depth,
+#if BOOST_VERSION < 106500                            
                             std::tr1::unordered_set<Stackage*>& deps_hash,
-                            std::vector<Stackage*>& deps,
-                            bool get_indented_deps,
-                            std::vector<std::string>& indented_deps,
-                            bool no_recursion_on_wet,
-                            std::vector<std::string>& dep_chain)
-#else
-void
-_gatherDepsFull(Stackage* stackage, bool direct,
-                            traversal_order_t order, int depth,
+#else                            
                             boost::unordered_set<Stackage*>& deps_hash,
+#endif                            
                             std::vector<Stackage*>& deps,
                             bool get_indented_deps,
                             std::vector<std::string>& indented_deps,
                             bool no_recursion_on_wet,
                             std::vector<std::string>& dep_chain)
-#endif
 {
   if(stackage->is_wet_package_ && no_recursion_on_wet)
   {
@@ -1965,25 +1938,18 @@ _gatherDepsFull(Stackage* stackage, bool direct,
 }
 
 // Pre-condition: computeDeps(stackage) succeeded
-#if BOOST_VERSION <= 106500
 void
 Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
                             traversal_order_t order, int depth,
+#if BOOST_VERSION < 106500                            
                             std::tr1::unordered_set<Stackage*>& deps_hash,
-                            std::vector<Stackage*>& deps,
-                            bool get_indented_deps,
-                            std::vector<std::string>& indented_deps,
-                            bool no_recursion_on_wet)
-#else
-void
-Rosstackage::gatherDepsFull(Stackage* stackage, bool direct,
-                            traversal_order_t order, int depth,
+#else                            
                             boost::unordered_set<Stackage*>& deps_hash,
+#endif                            
                             std::vector<Stackage*>& deps,
                             bool get_indented_deps,
                             std::vector<std::string>& indented_deps,
                             bool no_recursion_on_wet)
-#endif
 {
   std::vector<std::string> dep_chain;
   dep_chain.push_back(stackage->name_);
@@ -2166,15 +2132,13 @@ Rosstackage::writeCache()
       {
         char *rpp = getenv("ROS_PACKAGE_PATH");
         fprintf(cache, "#ROS_PACKAGE_PATH=%s\n", (rpp ? rpp : ""));
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
         for(std::tr1::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
-            it != stackages_.end();
-            ++it)
-#else
+#else   
         for(boost::unordered_map<std::string, Stackage*>::const_iterator it = stackages_.begin();
+#endif
             it != stackages_.end();
             ++it)
-#endif
           fprintf(cache, "%s\n", it->second->path_.c_str());
         fclose(cache);
         if(fs::exists(cache_path))

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -28,7 +28,11 @@
 #include <string>
 #include <vector>
 #include <boost/algorithm/string.hpp>
+#if BOOST_VERSION <= 106500
 #include <boost/tr1/unordered_set.hpp>
+#else
+#include <boost/unordered_set.hpp>
+#endif
 
 #include "utils.h"
 
@@ -41,7 +45,11 @@ deduplicate_tokens(const std::string& instring,
                    std::string& outstring)
 {
   std::vector<std::string> vec;
+#if BOOST_VERSION <= 106500
   std::tr1::unordered_set<std::string> set;
+#else
+  boost::unordered_set<std::string> set;
+#endif
   boost::split(vec, instring,
                boost::is_any_of("\t "),
                boost::token_compress_on);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 #include <boost/algorithm/string.hpp>
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
 #include <boost/tr1/unordered_set.hpp>
 #else
 #include <boost/unordered_set.hpp>
@@ -45,7 +45,7 @@ deduplicate_tokens(const std::string& instring,
                    std::string& outstring)
 {
   std::vector<std::string> vec;
-#if BOOST_VERSION <= 106500
+#if BOOST_VERSION < 106500
   std::tr1::unordered_set<std::string> set;
 #else
   boost::unordered_set<std::string> set;


### PR DESCRIPTION
Addresses https://github.com/ros/rospack/issues/92 when compiling ROS Kinetic on various platforms with BOOST_VERSION >= 1.65.

Mitigates concerns in https://github.com/ros/rospack/pull/93 by using `BOOST_VERSION` to infer the correct boost headers to use (and functions in the rest of the code).