### PR TITLE
Bump to CMake 3.0.2 to avoid CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.0.2)
 project(rospack)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.7.2)
 project(rospack)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules)


### PR DESCRIPTION
This bumps the minimum CMake version to 3.7.2, which is the [minimum supported by ROS Melodic](https://www.ros.org/reps/rep-0003.html#melodic-morenia-may-2018-may-2023) and more than new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building this package in Debian Buster and Ubuntu Focal.

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>