### PR TITLE
[melodic]: Switch dependency back to python-rosdep.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -30,8 +30,12 @@
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg-modules</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg-modules</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep-modules</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep-modules</exec_depend>
+  <!-- This package really only depends on python-rosdep-modules, but in order
+       to keep installing the rosdep command-line tool in Melodic we depend on
+       python-rosdep.
+  -->
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep</exec_depend>
   <exec_depend>ros_environment</exec_depend>
 
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-coverage</test_depend>


### PR DESCRIPTION
Prior to https://github.com/ros/rospack/pull/109 , installing
ros-melodic-desktop on Melodic installed the `rosdep` command-line.
After that change, it no longer does.  For backwards compatibility
reasons, revert that change just for melodic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

If we don't want to change this dependency back, I'd suggest that the other place to make this change is in https://github.com/ros/metapackages/blob/melodic-devel/ros_core/package.xml .  @dirk-thomas thoughts?