### PR TITLE
Set umask before opening cache file

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -2060,8 +2060,8 @@ Rosstackage::writeCache()
       FILE *cache = fopen(tmp_cache_path, "w");
 #else
     mode_t mask = umask(S_IRWXU);
-    int fd = mkstemp(tmp_cache_path);
     umask(mask);
+    int fd = mkstemp(tmp_cache_path);
     if (fd < 0)
     {
       fprintf(stderr, "[rospack] Unable to create temporary cache file %s: %s\n",


### PR DESCRIPTION
As per `MKSTEMP(3)`:

> More generally, the POSIX specification of mkstemp() does not say  any‐
> thing  about  file  modes, so the application should make sure its file
> mode creation mask (see umask(2)) is set appropriately  before  calling
> mkstemp() (and mkostemp()).

setting umask *before* file creation should fix ros/rospack#117

https://answers.ros.org/question/351675/rospack-cache-files-in-ros-directory-with-no-access-rights/

 #Coronavirus #Bugfix