### PR TITLE
fix umask for rospack cache files

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -2076,7 +2076,7 @@ Rosstackage::writeCache()
     {
       FILE *cache = fopen(tmp_cache_path, "w");
 #else
-    mode_t mask = umask(S_IRWXU);
+    mode_t mask = umask(S_IXUSR  | S_IRWXG | S_IRWXO);
     int fd = mkstemp(tmp_cache_path);
     umask(mask);
     if (fd < 0)


### PR DESCRIPTION
Fixes #117. The regression was introduced in #106.

This needs to be backported to `melodic-devel`.