### PR TITLE
[kinetic] Replace 'rosdep' by 'rosdep-modules'

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,13 +17,23 @@
   <author>Morgan Quigley</author>
   <author>Dirk Thomas</author>
 
+  <depend>boost</depend>
+  <depend>pkg-config</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python</depend>
+  <depend>tinyxml</depend>
+
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>gtest</build_depend>
 
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg-modules</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg-modules</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep-modules</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep-modules</exec_depend>
   <exec_depend>ros_environment</exec_depend>
 
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-coverage</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-coverage</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rospack</name>
   <version>2.4.5</version>
   <description>ROS Package Tool</description>
@@ -15,20 +19,11 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>gtest</build_depend>
-  <build_depend>pkg-config</build_depend>
-  <build_depend>python</build_depend>
-  <build_depend>tinyxml</build_depend>
 
-  <run_depend>boost</run_depend>
-  <run_depend>pkg-config</run_depend>
-  <run_depend>python</run_depend>
-  <run_depend>python-catkin-pkg</run_depend>
-  <run_depend>python-rosdep</run_depend>
-  <run_depend>ros_environment</run_depend>
-  <run_depend>tinyxml</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep-modules</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep-modules</exec_depend>
+  <exec_depend>ros_environment</exec_depend>
 
-  <test_depend>python-coverage</test_depend>
 </package>


### PR DESCRIPTION
**Feature**: 
Backport #109 to kinetic branch and also update the package manifest following the one at melodic-devel branch

**Description:**
I've noticed [here](https://github.com/ros-infrastructure/rosdep/issues/745#issuecomment-720735220) that only ros-kinetic-core image from osrf dockerhub was automatically installing rosdep. Since that is not the desirable behavior anymore I'm backporting the #109 update to set the dependency against 'rosdep-modules'