### PR TITLE
Kinetic backports for package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rospack</name>
   <version>2.4.5</version>
   <description>ROS Package Tool</description>
@@ -13,22 +17,23 @@
   <author>Morgan Quigley</author>
   <author>Dirk Thomas</author>
 
+  <depend>boost</depend>
+  <depend>pkg-config</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
+  <depend>tinyxml</depend>
+
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>gtest</build_depend>
-  <build_depend>pkg-config</build_depend>
-  <build_depend>python</build_depend>
-  <build_depend>tinyxml</build_depend>
 
-  <run_depend>boost</run_depend>
-  <run_depend>pkg-config</run_depend>
-  <run_depend>python</run_depend>
-  <run_depend>python-catkin-pkg</run_depend>
-  <run_depend>python-rosdep</run_depend>
-  <run_depend>ros_environment</run_depend>
-  <run_depend>tinyxml</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep</exec_depend>
+  <exec_depend>ros_environment</exec_depend>
 
-  <test_depend>python-coverage</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-coverage</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-coverage</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -28,10 +28,10 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>gtest</build_depend>
 
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg-modules</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg-modules</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rosdep-modules</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rosdep-modules</exec_depend>
   <exec_depend>ros_environment</exec_depend>
 
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-coverage</test_depend>


### PR DESCRIPTION
Backporting the following two changes to the package.xml to Kinetic:

- use condition attributes to specify Python 2 and 3 dependencies (#107)
- only depend on catkin_pkg/rosdep-modules (#109)
