### PR TITLE
fixes `rospack export` for package with condition attrib

### DIFF
--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -1630,6 +1630,76 @@ Rosstackage::computeDepsInternal(Stackage* stackage, bool ignore_errors, const s
       dep_ele;
       dep_ele = dep_ele->NextSiblingElement(depend_tag.c_str()))
   {
+    // check condition
+    const char* condition = dep_ele->Attribute("condition");
+    if ( condition != NULL )
+    {
+      std::istringstream condition_stream(condition);
+      std::string l, op, r;
+      condition_stream >> l;
+      condition_stream >> op;
+      condition_stream >> r;
+      // get environment variable if it starts with $
+      if ( l.rfind("$", 0) == 0 )
+      {
+        char* env = std::getenv(l.erase(0, 1).c_str());
+        if ( env != NULL )
+        {
+          l = std::string(env);
+        }
+        else
+        {
+          l = std::string("");
+        }
+      }
+      if ( r.rfind("$", 0) == 0 )
+      {
+        char* env = std::getenv(r.erase(0, 1).c_str());
+        if ( env != NULL )
+        {
+          r = std::string(env);
+        }
+        else
+        {
+          r = std::string("");
+        }
+      }
+      if ( !l.empty() && !r.empty() )
+      {
+        int li, ri;
+        li = stoi( l );
+        ri = stoi( r );
+        if ( op == "=="  && !( li == ri ) )
+        {
+          continue;
+        }
+        else if ( op == "!="  && !( li != ri ) )
+        {
+          continue;
+        }
+        else if ( op == "<"  && !( li < ri ) )
+        {
+          continue;
+        }
+        else if ( op == "<="  && !( li <= ri ) )
+        {
+          continue;
+        }
+        else if ( op == ">"  && !( li > ri ) )
+        {
+          continue;
+        }
+        else if ( op == ">="  && !( li >= ri ) )
+        {
+          continue;
+        }
+      }
+      else
+      {
+        continue;
+      }
+    }
+    //
     if (!stackage->is_wet_package_)
     {
       dep_pkgname = dep_ele->Attribute(tag_.c_str());

--- a/test/test/deps_condition/manifest.xml
+++ b/test/test/deps_condition/manifest.xml
@@ -1,0 +1,8 @@
+<package>
+  <name>deps_condition</name>
+<depend condition="$NON_EXISTENT_PACKAGE == 0"
+        package="nonexistentpackage" />
+<depend condition="$ROS_VERSION == 1"
+        package="base_two" />
+<depend package="base"/>
+</package>

--- a/test/test/utest.py.in
+++ b/test/test/utest.py.in
@@ -636,7 +636,7 @@ class RospackTestCase(unittest.TestCase):
 
         self.rospack_succeed("deps", "depends-on")
         tests = [
-            (["plugins", "deps_dup", "deps", "deps_higher"], "base"),
+            (["plugins", "deps_dup", "deps", "deps_higher", "deps_condition"], "base"),
             (["deps_higher","deps_dup"], "deps"),
             ([], "depth-0"),
             (depth_list, "depth-100"),
@@ -648,8 +648,8 @@ class RospackTestCase(unittest.TestCase):
         self.rospack_succeed("deps", "depends-on")
         tests = [
             (["deps_higher"], "deps"),
-            (["deps", "deps_dup", "plugins"], "base"),
-            (["deps", "deps_dup"], "base_two"),            
+            (["deps", "deps_dup", "plugins", "deps_condition"], "base"),
+            (["deps", "deps_dup", "deps_condition"], "base_two"),
             ]
         self.check_unordered_list("depends-on1", tests)
 
@@ -660,6 +660,14 @@ class RospackTestCase(unittest.TestCase):
             (["deps_nonexistent"], "nonexistentpackage"),
             ]
         self.check_ordered_list("depends-on", tests)
+
+    def test_deps_condition(self):
+        pass
+        self.rospack_succeed("deps_condition", "depends-on")
+        tests = [
+            (["base", "base_two"], "deps_condition"),
+            ]
+        self.check_unordered_list("depends", tests)
 
     def test_lflags_base(self):
         self.rospack_succeed("base", "libs-only-l")


### PR DESCRIPTION
For example
```
$ rospack export --lang=cpp --attrib=cflags eigenpy
```
returns error with
```
[rospack] Error: package 'eigenpy' depends on non-existent package 'ament_cmake' and rosdep claims that it is not a system dependency. Check the ROS_PACKAGE_PATH or try calling 'rosdep update
```

If we have https://github.com/ros/rospack/pull/113, it will outputs the result, but on melodic, we can not run `export` if for example eigenpy and other packages wihch skip rosdep rule by condition attribute, failing

This pr check `condition` attribute and evaluate them